### PR TITLE
Debug cluster create

### DIFF
--- a/infra/install-infractl/action.yml
+++ b/infra/install-infractl/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         mkdir -p ~/.local/bin
-        curl --fail -sL https://infra.rox.systems/v1/cli/linux/amd64/upgrade \
+        curl --fail -sL https://infra.stackrox.com/v1/cli/linux/amd64/upgrade \
         | jq -r ".result.fileChunk" \
         | base64 -d \
         > ~/.local/bin/infractl


### PR DESCRIPTION
WIP. Why does create-cluster fail like https://github.com/stackrox/infra/actions/runs/5481654686
```
Will attempt to create the cluster.
Warning: The job will wait for the cluster creation to finish.
NOTE: infractl no longer requires a NAME parameter when creating a cluster.
      If ommitted a name will be generated using your infra user initials, a
      short date and a counter for uniqueness. e.g. jb-10-31-1
Error: rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR
Error: Process completed with exit code 1.
```

And then with the debug commands added its fine: https://github.com/stackrox/infra/actions/runs/5481937930/jobs/9986775555

And then fails again:
https://github.com/stackrox/infra/actions/runs/5482238922/jobs/9987369505?pr=772