### PR TITLE
Increase default timeout waiting for RC images to 60m

### DIFF
--- a/release/wait-for-image/action.yml
+++ b/release/wait-for-image/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: "30"
   limit:
     description: Time limit in seconds until give up waiting and fail
-    default: "2400"
+    default: "3600"
 
 runs:
   using: composite


### PR DESCRIPTION
See https://redhat-internal.slack.com/archives/C03D78P4RFF/p1688745442481709