### PR TITLE
Validate the infra token

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1,0 +1,32 @@
+name: Test Actions
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+
+jobs:
+  test-infra-create-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create a cluster
+        uses: ./infra/create-cluster@
+        with:
+          flavor: gke-default
+          name: actions-pr-${{ github.event.pull_request.number }}
+          args: machine-type=e2-medium,nodes=1,gcp-image-type=ubuntu_containerd
+          lifespan: 1h
+          wait: true
+          token: ${{ secrets.INFRA_TOKEN }}
+
+      - name: Repeat to test handling for existing clusters
+        uses: ./infra/create-cluster
+        with:
+          flavor: gke-default
+          name: actions-pr-${{ github.event.pull_request.number }}
+          args: machine-type=e2-medium,nodes=1,gcp-image-type=ubuntu_containerd
+          lifespan: 1h
+          wait: true
+          token: ${{ secrets.INFRA_TOKEN }}

--- a/infra/create-cluster/action.yml
+++ b/infra/create-cluster/action.yml
@@ -27,6 +27,14 @@ runs:
   using: composite
   steps:
     - uses: stackrox/actions/infra/install-infractl@main
+
+    - name: Validate the infractl install and its token
+      shell: bash
+      env:
+        INFRA_TOKEN: "${{ inputs.token }}"
+      run: |
+        infractl whoami
+
     - name: Create Cluster
       shell: bash
       env:


### PR DESCRIPTION
Adds an explicit `infractl whoami` to validate the infra token and the infractl download. This change also adds a PR workflow to test the create cluster action.