### PR TITLE
Add log entry regarding using Quay token

### DIFF
--- a/release/wait-for-image/wait-for-image.sh
+++ b/release/wait-for-image/wait-for-image.sh
@@ -23,8 +23,10 @@ find_tag() {
     URL="https://quay.io/api/v1/repository/$1/tag?specificTag=$2"
     {
         if [ -z "$TOKEN" ]; then
+            gh_log notice "Connecting to Quay without token"
             curl --silent --show-error --fail --location "$URL"
         else
+            gh_log notice "Connecting to Quay with token"
             curl --silent --show-error --fail --location "$URL" \
                 -H "Authorization: Bearer $TOKEN"
         fi


### PR DESCRIPTION
This is to ease the debugging of errors like this one: https://github.com/stackrox/test-gh-actions/actions/runs/5643385928/job/15285112984