### PR TITLE
ROX-19259: add git hook

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -216,7 +216,6 @@ jobs:
   create-long-running-cluster-for-fake-load:
     name: Create GKE long-running cluster for fake load
     needs: [wait-for-images]
-    dsfasdfa:
     # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
     if: >-
       github.event.inputs.dry-run != 'true' &&

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -216,6 +216,7 @@ jobs:
   create-long-running-cluster-for-fake-load:
     name: Create GKE long-running cluster for fake load
     needs: [wait-for-images]
+    dsfasdfa:
     # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
     if: >-
       github.event.inputs.dry-run != 'true' &&

--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ git push origin v1.2.3
 ```
 
 A Github action will create a short version, in this example `v1`, or move the `v1` tag to your new tag.
+
+## Setting up git hooks
+
+There is currently one pre-push git hook that runs actionlint. To use the pre-push git hook you must
+install actionlint and run `git config core.hooksPath ./githooks/` in the root of this repository.

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+top_dir="$(git rev-parse --show-toplevel)"
+
+pushd "$top_dir"
+
+if command -v actionlint > /dev/null; then
+    actionlint
+else
+    echo "You need to install actionlint"
+    exit 1
+fi


### PR DESCRIPTION
Adds an actionlint pre-push check. This is useful because developers will find syntax errors before trying to run their actions. This in turn speeds up development.

To actually use the pre-push check you will need to install actionlint and run the following command locally `git config core.hooksPath ./githooks/`

## Checklist

- [x] Pre-push hook prevents pushing when there is syntax error in a workflow yaml file
- [x] Pre-push hook does not prevent commiting when there is a syntax error
- [x] It is still possible to make commits when there are no syntax errors
- [x] It is still possible to push when there are no syntax errors

## Testing
```
git config core.hooksPath ./githooks/

vi create-demo-clusters.yml
git add .github/workflows/create-demo-clusters.yml
git commit -m "Made intentional syntax error"
Made intentional syntax error
 1 file changed, 1 insertion(+)
[jvirtane@jvirtane actions]$ git push origin HEAD
~/go/src/github.com/stackrox/actions ~/go/src/github.com/stackrox/actions
.github/workflows/create-demo-clusters.yml:219:5: unexpected key "dsfasdfa" for "job" section. expected one of "concurrency", "container", "continue-on-error", "defaults", "env", "environment", "if", "name", "needs", "outputs", "permissions", "runs-on", "secrets", "services", "steps", "strategy", "timeout-minutes", "uses", "with" [syntax-check]
    |
219 |     dsfasdfa:
    |     ^~~~~~~~~
error: failed to push some refs to 'github.com:stackrox/actions.git'
```

```
vi create-demo-clusters.yml
git add .github/workflows/create-demo-clusters.yml

git commit -m "Removed intentional syntax error"
[jv-add-git-hook 1995c44] Removed intentional syntax error
 1 file changed, 1 deletion(-)
[jvirtane@jvirtane actions]$ gitpush 
~/go/src/github.com/stackrox/actions ~/go/src/github.com/stackrox/actions
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 12 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 662 bytes | 662.00 KiB/s, done.
Total 6 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:stackrox/actions.git
   4985c21..1995c44  HEAD -> jv-add-git-hook
```