### PR TITLE
chore: set development telemetry key

### DIFF
--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -49,6 +49,7 @@ runs:
         KUBECONFIG: ${{ inputs.kubeconfig }}
         STACKROX_DIR: ${{ inputs.stackrox-dir }}
         NAME: ${{ inputs.name }}
+        ROX_TELEMETRY_STORAGE_KEY_V1: R5fMyO9n0gibSGzOXtlP2qCFWCGb8uoW
       run: |
         set -uo pipefail
         "${{ github.action_path }}/../../common/common.sh" \


### PR DESCRIPTION
The key instructs central to forward telemetry to the bucket for development data.