### PR TITLE
ROX-19415: long-running cluster should only be created for RC.1 (fixing input parameters to called workflow)

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -218,8 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "{{ github.event.inputs.create-long-cluster }}"
-          echo "{{github.event.inputs.create-long-cluster != 'false'}}"
+          echo "${{ github.event.inputs.create-long-cluster }}"
+          echo "${{ github.event.inputs.create-long-cluster != 'false' }}"
 
 
   # create-long-running-cluster-for-fake-load:

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -9,19 +9,19 @@ on:
       create-k8s-cluster:
         description: Create a GKE demo cluster
         default: false
-        type: boolean
+        type: string
       create-os4-cluster:
         description: Create an Openshift 4 demo cluster
         default: false
-        type: boolean
+        type: string
       create-long-cluster:
         description: Create a long-running cluster on RC1
         default: false
-        type: boolean
+        type: string
       dry-run:
         description: Dry-run
         default: false
-        type: boolean
+        type: string
       workflow-ref:
         description: Ref of the called workflow
         type: string

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -41,7 +41,7 @@ on:
 env:
   main_branch: ${{github.event.repository.default_branch}}
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
-  DRY_RUN: ${{ fromJSON('["true", "false"]')[github.event.inputs.dry-run != 'true'] }}
+  DRY_RUN: ${{ fromJSON('["true", "false"]')[inputs.dry-run != 'true'] }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}
   GH_NO_UPDATE_NOTIFIER: 1
@@ -51,7 +51,7 @@ jobs:
   properties:
     runs-on: ubuntu-latest
     outputs:
-      slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[github.event.inputs.dry-run != 'true'] }}
+      slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[inputs.dry-run != 'true'] }}
       jira-projects: ${{ steps.fetch.outputs.jira-projects }}
     steps:
       - name: Read workflow properties file
@@ -89,8 +89,8 @@ jobs:
   # create-k8s-cluster:
   #   name: Create k8s cluster
   #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-  #   if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-k8s-cluster != 'false'
+  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+  #   if: inputs.dry-run != 'true' && inputs.create-k8s-cluster != 'false'
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout local action
@@ -152,8 +152,8 @@ jobs:
   # create-os4-cluster:
   #   name: Create OS4 cluster
   #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-  #   if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-os4-cluster != 'false'
+  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+  #   if: inputs.dry-run != 'true' && inputs.create-os4-cluster != 'false'
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout local action
@@ -218,17 +218,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "${{ inputs.create-long-cluster }}"
-          echo "${{ inputs.create-long-cluster != 'false' }}"
-
+          echo "create-os4-cluster: ${{ inputs.create-os4-cluster }}"
+          echo "create-k8s-cluster: ${{ inputs.create-k8s-cluster }}"
+          echo "create-long-running-cluster: ${{ inputs.create-long-cluster }}"
 
   # create-long-running-cluster-for-fake-load:
   #   name: Create GKE long-running cluster for fake load
   #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
   #   if: >-
-  #     github.event.inputs.dry-run != 'true' &&
-  #     github.event.inputs.create-long-cluster != 'false'
+  #     inputs.dry-run != 'true' &&
+  #     inputs.create-long-cluster != 'false'
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout local action
@@ -250,10 +250,10 @@ jobs:
   # create-long-running-cluster-for-real-load:
   #   name: Create GKE long-running cluster for real load
   #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
   #   if: >-
-  #     github.event.inputs.dry-run != 'true' &&
-  #     github.event.inputs.create-long-cluster != 'false'
+  #     inputs.dry-run != 'true' &&
+  #     inputs.create-long-cluster != 'false'
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout local action
@@ -317,7 +317,7 @@ jobs:
   #       id: launch-central
   #       uses: ./.actions/release/start-acs
   #       with:
-  #         main-image-tag: ${{github.event.inputs.version}}
+  #         main-image-tag: ${{inputs.version}}
   #         kubeconfig: ${{ env.KUBECONFIG }}
   #         registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
   #         registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -411,7 +411,7 @@ jobs:
   #     - name: Launch secured cluster
   #       id: launch-secured-cluster
   #       env:
-  #         MAIN_IMAGE_TAG: ${{github.event.inputs.version}} # Release version, e.g. 3.63.0-rc.2.
+  #         MAIN_IMAGE_TAG: ${{inputs.version}} # Release version, e.g. 3.63.0-rc.2.
   #         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
   #         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
   #         ROX_ADMIN_PASSWORD: ${{ needs.start-acs.outputs.rox_password }}

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -218,8 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "${{ github.event.inputs.create-long-cluster }}"
-          echo "${{ github.event.inputs.create-long-cluster != 'false' }}"
+          echo "${{ inputs.create-long-cluster }}"
+          echo "${{ inputs.create-long-cluster != 'false' }}"
 
 
   # create-long-running-cluster-for-fake-load:

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -306,6 +306,7 @@ jobs:
         with:
           main-image-tag: ${{inputs.version}}
           kubeconfig: ${{ env.KUBECONFIG }}
+          pagerduty-integration-key: ${{ secrets.RELEASE_MANAGEMENT_PAGERDUTY_INTEGRATION_KEY }}
           registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
           stackrox-dir: ${{ github.workspace }}

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -60,454 +60,463 @@ jobs:
           PROPERTIES_URL: /repos/${{ github.repository }}/contents/.github/properties?ref=${{ github.ref_name }}
         run: gh api -H "$ACCEPT_RAW" "$PROPERTIES_URL" >> "$GITHUB_OUTPUT"
 
-  wait-for-images:
-    name: Wait for images on Quay.io
-    runs-on: ubuntu-latest
-    if: >- # Skip if no clusters are going to be created.
-      inputs.create-k8s-cluster != 'false' ||
-      inputs.create-os4-cluster != 'false' ||
-      inputs.create-long-cluster != 'false'
-    strategy:
-      matrix:
-        image: [main, scanner, scanner-db, collector]
-    steps:
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - name: Wait for the ${{matrix.image}} image
-        uses: ./.actions/release/wait-for-image
-        with:
-          token: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
-          image: "rhacs-eng/${{ matrix.image }}:${{ inputs.version }}"
-          # Do not wait if running dry
-          interval: ${{ fromJSON('["30", "0"]')[env.DRY_RUN == 'true'] }}
-          limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[env.DRY_RUN == 'true'] }}
+  # wait-for-images:
+  #   name: Wait for images on Quay.io
+  #   runs-on: ubuntu-latest
+  #   if: >- # Skip if no clusters are going to be created.
+  #     inputs.create-k8s-cluster != 'false' ||
+  #     inputs.create-os4-cluster != 'false' ||
+  #     inputs.create-long-cluster != 'false'
+  #   strategy:
+  #     matrix:
+  #       image: [main, scanner, scanner-db, collector]
+  #   steps:
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - name: Wait for the ${{matrix.image}} image
+  #       uses: ./.actions/release/wait-for-image
+  #       with:
+  #         token: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
+  #         image: "rhacs-eng/${{ matrix.image }}:${{ inputs.version }}"
+  #         # Do not wait if running dry
+  #         interval: ${{ fromJSON('["30", "0"]')[env.DRY_RUN == 'true'] }}
+  #         limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[env.DRY_RUN == 'true'] }}
 
-  create-k8s-cluster:
-    name: Create k8s cluster
-    needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-    if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-k8s-cluster != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: ./.actions/infra/create-cluster
-        with:
-          token: ${{ secrets.INFRA_TOKEN }}
-          flavor: qa-demo
-          name: qa-k8s-${{ inputs.version }}
-          args: main-image=quay.io/rhacs-eng/main:${{ inputs.version }},central-db-image=quay.io/rhacs-eng/central-db:${{ inputs.version }}
-          lifespan: 48h
+  # create-k8s-cluster:
+  #   name: Create k8s cluster
+  #   needs: [wait-for-images]
+  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-k8s-cluster != 'false'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: ./.actions/infra/create-cluster
+  #       with:
+  #         token: ${{ secrets.INFRA_TOKEN }}
+  #         flavor: qa-demo
+  #         name: qa-k8s-${{ inputs.version }}
+  #         args: main-image=quay.io/rhacs-eng/main:${{ inputs.version }},central-db-image=quay.io/rhacs-eng/central-db:${{ inputs.version }}
+  #         lifespan: 48h
 
-  notify-k8s-cluster:
-    name: Notify about K8s cluster creation
-    needs: [properties, create-k8s-cluster]
-    runs-on: ubuntu-latest
-    env:
-      NAME: qa-k8s-${{ inputs.version }}
-    steps:
-      - name: Determine demo url and cluster name
-        id: get_demo_artifacts
-        run: |
-          echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
-          echo "url=https://${NAME//[.-]/}.demo.stackrox.com/login" >> "$GITHUB_OUTPUT"
-      - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "QA Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|QA demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":arrow_right: When it is ready in ca. 20 minutes, a notification will be posted in #acs-infra-notifications channel, and the cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} with your @stackrox.com Google account."
-                  }
-                }
-              ]
-            }
+  # notify-k8s-cluster:
+  #   name: Notify about K8s cluster creation
+  #   needs: [properties, create-k8s-cluster]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     NAME: qa-k8s-${{ inputs.version }}
+  #   steps:
+  #     - name: Determine demo url and cluster name
+  #       id: get_demo_artifacts
+  #       run: |
+  #         echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
+  #         echo "url=https://${NAME//[.-]/}.demo.stackrox.com/login" >> "$GITHUB_OUTPUT"
+  #     - name: Post to Slack
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       with:
+  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
+  #         payload: >-
+  #           {
+  #             "text": "QA Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|QA demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+  #                 }
+  #               },
+  #               {
+  #                 "type": "divider"
+  #               },
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":arrow_right: When it is ready in ca. 20 minutes, a notification will be posted in #acs-infra-notifications channel, and the cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} with your @stackrox.com Google account."
+  #                 }
+  #               }
+  #             ]
+  #           }
 
-  create-os4-cluster:
-    name: Create OS4 cluster
-    needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-    if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-os4-cluster != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: ./.actions/infra/create-cluster
-        with:
-          token: ${{ secrets.INFRA_TOKEN }}
-          flavor: openshift-4-demo
-          name: openshift-4-demo-${{ inputs.version }}
-          args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }}
-          lifespan: 48h
+  # create-os4-cluster:
+  #   name: Create OS4 cluster
+  #   needs: [wait-for-images]
+  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   if: github.event.inputs.dry-run != 'true' && github.event.inputs.create-os4-cluster != 'false'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: ./.actions/infra/create-cluster
+  #       with:
+  #         token: ${{ secrets.INFRA_TOKEN }}
+  #         flavor: openshift-4-demo
+  #         name: openshift-4-demo-${{ inputs.version }}
+  #         args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }}
+  #         lifespan: 48h
 
-  notify-os4-cluster:
-    name: Notify about Openshift cluster creation
-    needs: [properties, create-os4-cluster]
-    runs-on: ubuntu-latest
-    env:
-      NAME: openshift-4-demo-${{ inputs.version }}
-    steps:
-      - name: Determine demo url and cluster name
-        id: get_demo_artifacts
-        run: |
-          echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
-          echo "url=https://central-stackrox.apps.${NAME//./-}.openshift.infra.rox.systems/login" >> "$GITHUB_OUTPUT"
-      - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Openshift 4 Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
+  # notify-os4-cluster:
+  #   name: Notify about Openshift cluster creation
+  #   needs: [properties, create-os4-cluster]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     NAME: openshift-4-demo-${{ inputs.version }}
+  #   steps:
+  #     - name: Determine demo url and cluster name
+  #       id: get_demo_artifacts
+  #       run: |
+  #         echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
+  #         echo "url=https://central-stackrox.apps.${NAME//./-}.openshift.infra.rox.systems/login" >> "$GITHUB_OUTPUT"
+  #     - name: Post to Slack
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       with:
+  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
+  #         payload: >-
+  #           {
+  #             "text": "Openshift 4 Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
 
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":arrow_right: The cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} in ~40 minutes. You can find the admin password and kubeconfig with `infractl artifacts ${{ steps.get_demo_artifacts.outputs.cluster-name }}`."
-                  }
-                }
-              ]
-            }
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+  #                 }
+  #               },
+  #               {
+  #                 "type": "divider"
+  #               },
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":arrow_right: The cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} in ~40 minutes. You can find the admin password and kubeconfig with `infractl artifacts ${{ steps.get_demo_artifacts.outputs.cluster-name }}`."
+  #                 }
+  #               }
+  #             ]
+  #           }
 
-  create-long-running-cluster-for-fake-load:
-    name: Create GKE long-running cluster for fake load
-    needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-    if: >-
-      github.event.inputs.dry-run != 'true' &&
-      github.event.inputs.create-long-cluster != 'false'
+  debug:
+    name: debug
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: ./.actions/infra/create-cluster
-        with:
-          token: ${{ secrets.INFRA_TOKEN }}
-          flavor: gke-default
-          name: ${{ inputs.cluster-with-fake-load-name }}
-          lifespan: 168h
-          args: nodes=5,machine-type=e2-standard-8
-          wait: true
-
-  # TODO ROX-19190 Don't DRY. Make this and the above into a separate action.
-  create-long-running-cluster-for-real-load:
-    name: Create GKE long-running cluster for real load
-    needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
-    if: >-
-      github.event.inputs.dry-run != 'true' &&
-      github.event.inputs.create-long-cluster != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: ./.actions/infra/create-cluster
-        with:
-          token: ${{ secrets.INFRA_TOKEN }}
-          flavor: gke-default
-          name: ${{ inputs.cluster-with-real-load-name }}
-          lifespan: 168h
-          args: nodes=5,machine-type=e2-standard-8
-          wait: true
-
-  start-acs:
-    name: Start ACS
-    needs: [properties, create-long-running-cluster-for-fake-load]
-    runs-on: ubuntu-latest
-    outputs:
-      rox_password: ${{ steps.get-central-info.outputs.rox_password }}
-      central-ip: ${{ steps.get-central-info.outputs.central-ip }}
-    env:
-      NAME: ${{ inputs.cluster-with-fake-load-name }}
-      KUBECONFIG: artifacts/kubeconfig
-      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-    steps:
-      - uses: stackrox/actions/infra/install-infractl@v1
-      - name: Test readiness
-        run: |
-          STATUS=$(infractl get "${NAME//./-}" --json | jq -r .Status)
-          if [ "$STATUS" != "READY" ]; then
-            exit 1
-          fi
-      - name: Check out stackrox code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{inputs.version}}
-          repository: stackrox/stackrox
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: "google-github-actions/auth@v1"
-        with:
-          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
-        with:
-          install_components: "gke-gcloud-auth-plugin"
-      - name: Download artifacts
-        id: artifacts
-        run: |
-          infractl artifacts "${NAME//./-}" -d artifacts >> "$GITHUB_STEP_SUMMARY"
-      - name: Launch central
-        id: launch-central
-        uses: ./.actions/release/start-acs
-        with:
-          main-image-tag: ${{github.event.inputs.version}}
-          kubeconfig: ${{ env.KUBECONFIG }}
-          registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-          registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-          stackrox-dir: ${{ github.workspace }}
-          name: ${{ env.NAME }}
-      # TODO ROX-19190 Get this information from the previous step
-      - name: Get central info
-        id: get-central-info
-        run: |
-          CENTRAL_IP=$(kubectl -n stackrox get svc/central-loadbalancer -o json | jq -r '.status.loadBalancer.ingress[0] | .ip // .hostname')
-          ROX_ADMIN_PASSWORD=$(cat ${{ github.workspace }}/deploy/k8s/central-deploy/password)
-          echo "rox_password=${ROX_ADMIN_PASSWORD}" >> "$GITHUB_OUTPUT"
-          echo "central-ip=${CENTRAL_IP}" >> "$GITHUB_OUTPUT"
+      - run: |
+          echo "{{ github.event.inputs.create-long-cluster }}"
+          echo "{{github.event.inputs.create-long-cluster != 'false'}}"
 
 
-      - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Long-running cluster created. Setup your local access with `scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}`",
+  # create-long-running-cluster-for-fake-load:
+  #   name: Create GKE long-running cluster for fake load
+  #   needs: [wait-for-images]
+  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   if: >-
+  #     github.event.inputs.dry-run != 'true' &&
+  #     github.event.inputs.create-long-cluster != 'false'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: ./.actions/infra/create-cluster
+  #       with:
+  #         token: ${{ secrets.INFRA_TOKEN }}
+  #         flavor: gke-default
+  #         name: ${{ inputs.cluster-with-fake-load-name }}
+  #         lifespan: 168h
+  #         args: nodes=5,machine-type=e2-standard-8
+  #         wait: true
 
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: *Long-running cluster `${{ inputs.cluster-with-fake-load-name }}` created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":arrow_right: Setup your local access to Central by running:\n```curl -L https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}```"
-                  }
-                }
-              ]
-            }
+  # # TODO ROX-19190 Don't DRY. Make this and the above into a separate action.
+  # create-long-running-cluster-for-real-load:
+  #   name: Create GKE long-running cluster for real load
+  #   needs: [wait-for-images]
+  #   # Cannot use env.DRY_RUN here. `github.event.inputs.*` can be 'true', 'false' or empty.
+  #   if: >-
+  #     github.event.inputs.dry-run != 'true' &&
+  #     github.event.inputs.create-long-cluster != 'false'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: ./.actions/infra/create-cluster
+  #       with:
+  #         token: ${{ secrets.INFRA_TOKEN }}
+  #         flavor: gke-default
+  #         name: ${{ inputs.cluster-with-real-load-name }}
+  #         lifespan: 168h
+  #         args: nodes=5,machine-type=e2-standard-8
+  #         wait: true
 
-      - name: Start fake workload
-        env:
-          API_ENDPOINT: localhost:8000
-          ROX_PASSWORD: ${{ steps.get-central-info.outputs.rox_password }}
-        run: |
-          #echo "::add-mask::$ROX_PASSWORD"
-          kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &
-          sleep 20
-          ./scale/launch_workload.sh np-load
-          echo "Fake workload has been deployed to the long-running cluster" >> "$GITHUB_STEP_SUMMARY"
+  # start-acs:
+  #   name: Start ACS
+  #   needs: [properties, create-long-running-cluster-for-fake-load]
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     rox_password: ${{ steps.get-central-info.outputs.rox_password }}
+  #     central-ip: ${{ steps.get-central-info.outputs.central-ip }}
+  #   env:
+  #     NAME: ${{ inputs.cluster-with-fake-load-name }}
+  #     KUBECONFIG: artifacts/kubeconfig
+  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+  #   steps:
+  #     - uses: stackrox/actions/infra/install-infractl@v1
+  #     - name: Test readiness
+  #       run: |
+  #         STATUS=$(infractl get "${NAME//./-}" --json | jq -r .Status)
+  #         if [ "$STATUS" != "READY" ]; then
+  #           exit 1
+  #         fi
+  #     - name: Check out stackrox code
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{inputs.version}}
+  #         repository: stackrox/stackrox
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: "google-github-actions/auth@v1"
+  #       with:
+  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+  #     - name: "Set up Cloud SDK"
+  #       uses: "google-github-actions/setup-gcloud@v1"
+  #       with:
+  #         install_components: "gke-gcloud-auth-plugin"
+  #     - name: Download artifacts
+  #       id: artifacts
+  #       run: |
+  #         infractl artifacts "${NAME//./-}" -d artifacts >> "$GITHUB_STEP_SUMMARY"
+  #     - name: Launch central
+  #       id: launch-central
+  #       uses: ./.actions/release/start-acs
+  #       with:
+  #         main-image-tag: ${{github.event.inputs.version}}
+  #         kubeconfig: ${{ env.KUBECONFIG }}
+  #         registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+  #         registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+  #         stackrox-dir: ${{ github.workspace }}
+  #         name: ${{ env.NAME }}
+  #     # TODO ROX-19190 Get this information from the previous step
+  #     - name: Get central info
+  #       id: get-central-info
+  #       run: |
+  #         CENTRAL_IP=$(kubectl -n stackrox get svc/central-loadbalancer -o json | jq -r '.status.loadBalancer.ingress[0] | .ip // .hostname')
+  #         ROX_ADMIN_PASSWORD=$(cat ${{ github.workspace }}/deploy/k8s/central-deploy/password)
+  #         echo "rox_password=${ROX_ADMIN_PASSWORD}" >> "$GITHUB_OUTPUT"
+  #         echo "central-ip=${CENTRAL_IP}" >> "$GITHUB_OUTPUT"
 
-  start-secured-cluster:
-    name: Start secured cluster
-    needs: [properties, start-acs, create-long-running-cluster-for-real-load]
-    runs-on: ubuntu-latest
-    env:
-      SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
-      KUBECONFIG: artifacts/kubeconfig
-      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-    steps:
-      - uses: stackrox/actions/infra/install-infractl@v1
-      - name: Test readiness for secured cluster
-        run: |
-          STATUS=$(infractl get "${SECURED_CLUSTER_NAME//./-}" --json | jq -r .Status)
-          if [ "$STATUS" != "READY" ]; then
-            exit 1
-          fi
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{inputs.version}}
-          repository: stackrox/stackrox
-      - uses: "google-github-actions/auth@v1"
-        with:
-          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
-        with:
-          install_components: "gke-gcloud-auth-plugin"
-      - name: Download artifacts
-        id: artifacts
-        run: |
-          infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d artifacts
-      - name: Launch secured cluster
-        id: launch-secured-cluster
-        env:
-          MAIN_IMAGE_TAG: ${{github.event.inputs.version}} # Release version, e.g. 3.63.0-rc.2.
-          REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-          ROX_ADMIN_PASSWORD: ${{ needs.start-acs.outputs.rox_password }}
-          ROX_ADMIN_USERNAME: admin
-          CENTRAL_IP: ${{ needs.start-acs.outputs.central-ip }}
-          CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
-          API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
-          CLUSTER: secured-cluster
-        run: |
-          "${{ github.workspace }}"/deploy/k8s/sensor.sh
-           kubectl -n stackrox create secret generic access-rhacs --from-literal="username=${ROX_ADMIN_USERNAME}" --from-literal="password=${ROX_ADMIN_PASSWORD}" --from-literal="central_url=https://${CENTRAL_IP}":443
 
-  start-kube-burner:
-    name: Start kube-burner
-    needs: [properties, start-secured-cluster]
-    runs-on: ubuntu-latest
-    env:
-      SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
-      KUBECONFIG: ${{ github.workspace }}/artifacts/kubeconfig
-      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-    steps:
-      - uses: stackrox/actions/infra/install-infractl@v1
-      - name: Check out kube-burner config repository code
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/${{ inputs.kube-burner-config-repo }}
-          path: .kube-burner-config
-          ref: ${{ inputs.kube-burner-config-ref }}
-      - name: Check out cloud-bulldozer/benchmark-operator code
-        run: |
-          git clone https://github.com/cloud-bulldozer/benchmark-operator.git
-          cd ${{ github.workspace }}/benchmark-operator
-          git checkout 081359d2a90ba556a603840b18015d10d05a89ec
-      - name: Checkout local action
-        uses: actions/checkout@v3
-        with:
-          repository: stackrox/actions
-          path: .actions
-          ref: ${{ inputs.workflow-ref }}
-      - uses: "google-github-actions/auth@v1"
-        with:
-          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
-        with:
-          install_components: "gke-gcloud-auth-plugin"
-      - name: Download artifacts
-        id: artifacts
-        run: |
-          infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d ${{ github.workspace }}/artifacts
-      - name: Launch kube-burner
-        id: launch-kube-burner
-        env:
-          REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-        uses: ./.actions/release/start-kube-burner
-        with:
-          kube-burner-config-dir: ./.kube-burner-config/scripts/release-tools/kube-burner-configs
-          benchmark-operator-dir: ${{ github.workspace }}/benchmark-operator
+  #     - name: Post to Slack
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       with:
+  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
+  #         payload: >-
+  #           {
+  #             "text": "Long-running cluster created. Setup your local access with `scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}`",
 
-  notify-failed-clusters:
-    name: Notify about failed cluster creation
-    needs:
-      [
-        properties,
-        create-k8s-cluster,
-        create-os4-cluster,
-        create-long-running-cluster-for-fake-load,
-        create-long-running-cluster-for-real-load,
-      ]
-    if:
-      >- # Required as create-*-cluster jobs could be skipped while other jobs could fail.
-      always() && (
-        needs.create-k8s-cluster.result == 'failure' ||
-        needs.create-os4-cluster.result == 'failure' ||
-        needs.create-long-running-cluster-for-fake-load.result == 'failure' ||
-        needs.create-long-running-cluster-for-real-load.result == 'failure'
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Couldn't create test cluster. Check <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" for details",
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":tada: *Long-running cluster `${{ inputs.cluster-with-fake-load-name }}` created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+  #                 }
+  #               },
+  #               {
+  #                 "type": "divider"
+  #               },
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": ":arrow_right: Setup your local access to Central by running:\n```curl -L https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}```"
+  #                 }
+  #               }
+  #             ]
+  #           }
 
-              "blocks": [
-              { "type": "section", "text": { "type": "mrkdwn", "text":
-              ":red_circle: *Couldn't create test clusters for ${{inputs.version}} milestone of <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*" }},
+  #     - name: Start fake workload
+  #       env:
+  #         API_ENDPOINT: localhost:8000
+  #         ROX_PASSWORD: ${{ steps.get-central-info.outputs.rox_password }}
+  #       run: |
+  #         #echo "::add-mask::$ROX_PASSWORD"
+  #         kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &
+  #         sleep 20
+  #         ./scale/launch_workload.sh np-load
+  #         echo "Fake workload has been deployed to the long-running cluster" >> "$GITHUB_STEP_SUMMARY"
 
-            { "type": "divider" },
+  # start-secured-cluster:
+  #   name: Start secured cluster
+  #   needs: [properties, start-acs, create-long-running-cluster-for-real-load]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
+  #     KUBECONFIG: artifacts/kubeconfig
+  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+  #   steps:
+  #     - uses: stackrox/actions/infra/install-infractl@v1
+  #     - name: Test readiness for secured cluster
+  #       run: |
+  #         STATUS=$(infractl get "${SECURED_CLUSTER_NAME//./-}" --json | jq -r .Status)
+  #         if [ "$STATUS" != "READY" ]; then
+  #           exit 1
+  #         fi
+  #     - name: Check out code
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{inputs.version}}
+  #         repository: stackrox/stackrox
+  #     - uses: "google-github-actions/auth@v1"
+  #       with:
+  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+  #     - name: "Set up Cloud SDK"
+  #       uses: "google-github-actions/setup-gcloud@v1"
+  #       with:
+  #         install_components: "gke-gcloud-auth-plugin"
+  #     - name: Download artifacts
+  #       id: artifacts
+  #       run: |
+  #         infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d artifacts
+  #     - name: Launch secured cluster
+  #       id: launch-secured-cluster
+  #       env:
+  #         MAIN_IMAGE_TAG: ${{github.event.inputs.version}} # Release version, e.g. 3.63.0-rc.2.
+  #         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+  #         ROX_ADMIN_PASSWORD: ${{ needs.start-acs.outputs.rox_password }}
+  #         ROX_ADMIN_USERNAME: admin
+  #         CENTRAL_IP: ${{ needs.start-acs.outputs.central-ip }}
+  #         CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
+  #         API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
+  #         CLUSTER: secured-cluster
+  #       run: |
+  #         "${{ github.workspace }}"/deploy/k8s/sensor.sh
+  #          kubectl -n stackrox create secret generic access-rhacs --from-literal="username=${ROX_ADMIN_USERNAME}" --from-literal="password=${ROX_ADMIN_PASSWORD}" --from-literal="central_url=https://${CENTRAL_IP}":443
 
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: *Please investigate the output of the
-            <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
-            workflow run and then restart the workflow.*" }},
+  # start-kube-burner:
+  #   name: Start kube-burner
+  #   needs: [properties, start-secured-cluster]
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
+  #     KUBECONFIG: ${{ github.workspace }}/artifacts/kubeconfig
+  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+  #   steps:
+  #     - uses: stackrox/actions/infra/install-infractl@v1
+  #     - name: Check out kube-burner config repository code
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/${{ inputs.kube-burner-config-repo }}
+  #         path: .kube-burner-config
+  #         ref: ${{ inputs.kube-burner-config-ref }}
+  #     - name: Check out cloud-bulldozer/benchmark-operator code
+  #       run: |
+  #         git clone https://github.com/cloud-bulldozer/benchmark-operator.git
+  #         cd ${{ github.workspace }}/benchmark-operator
+  #         git checkout 081359d2a90ba556a603840b18015d10d05a89ec
+  #     - name: Checkout local action
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: stackrox/actions
+  #         path: .actions
+  #         ref: ${{ inputs.workflow-ref }}
+  #     - uses: "google-github-actions/auth@v1"
+  #       with:
+  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+  #     - name: "Set up Cloud SDK"
+  #       uses: "google-github-actions/setup-gcloud@v1"
+  #       with:
+  #         install_components: "gke-gcloud-auth-plugin"
+  #     - name: Download artifacts
+  #       id: artifacts
+  #       run: |
+  #         infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d ${{ github.workspace }}/artifacts
+  #     - name: Launch kube-burner
+  #       id: launch-kube-burner
+  #       env:
+  #         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+  #         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+  #       uses: ./.actions/release/start-kube-burner
+  #       with:
+  #         kube-burner-config-dir: ./.kube-burner-config/scripts/release-tools/kube-burner-configs
+  #         benchmark-operator-dir: ${{ github.workspace }}/benchmark-operator
 
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ">
-            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
-            Milestone: ${{inputs.version}}\n>
-            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
-            ]}
+  # notify-failed-clusters:
+  #   name: Notify about failed cluster creation
+  #   needs:
+  #     [
+  #       properties,
+  #       create-k8s-cluster,
+  #       create-os4-cluster,
+  #       create-long-running-cluster-for-fake-load,
+  #       create-long-running-cluster-for-real-load,
+  #     ]
+  #   if:
+  #     >- # Required as create-*-cluster jobs could be skipped while other jobs could fail.
+  #     always() && (
+  #       needs.create-k8s-cluster.result == 'failure' ||
+  #       needs.create-os4-cluster.result == 'failure' ||
+  #       needs.create-long-running-cluster-for-fake-load.result == 'failure' ||
+  #       needs.create-long-running-cluster-for-real-load.result == 'failure'
+  #     )
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Post to Slack
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       with:
+  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
+  #         payload: >-
+  #           {
+  #             "text": "Couldn't create test cluster. Check <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" for details",
+
+  #             "blocks": [
+  #             { "type": "section", "text": { "type": "mrkdwn", "text":
+  #             ":red_circle: *Couldn't create test clusters for ${{inputs.version}} milestone of <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*" }},
+
+  #           { "type": "divider" },
+
+  #           { "type": "section", "text": { "type": "mrkdwn", "text":
+  #           ":arrow_right: *Please investigate the output of the
+  #           <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
+  #           workflow run and then restart the workflow.*" }},
+
+  #           { "type": "section", "text": { "type": "mrkdwn", "text":
+  #           ">
+  #           Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
+  #           Milestone: ${{inputs.version}}\n>
+  #           Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
+  #           ]}

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -9,19 +9,19 @@ on:
       create-k8s-cluster:
         description: Create a GKE demo cluster
         default: false
-        type: string
+        type: boolean
       create-os4-cluster:
         description: Create an Openshift 4 demo cluster
         default: false
-        type: string
+        type: boolean
       create-long-cluster:
         description: Create a long-running cluster on RC1
         default: false
-        type: string
+        type: boolean
       dry-run:
         description: Dry-run
         default: false
-        type: string
+        type: boolean
       workflow-ref:
         description: Ref of the called workflow
         type: string
@@ -60,463 +60,454 @@ jobs:
           PROPERTIES_URL: /repos/${{ github.repository }}/contents/.github/properties?ref=${{ github.ref_name }}
         run: gh api -H "$ACCEPT_RAW" "$PROPERTIES_URL" >> "$GITHUB_OUTPUT"
 
-  # wait-for-images:
-  #   name: Wait for images on Quay.io
-  #   runs-on: ubuntu-latest
-  #   if: >- # Skip if no clusters are going to be created.
-  #     inputs.create-k8s-cluster != 'false' ||
-  #     inputs.create-os4-cluster != 'false' ||
-  #     inputs.create-long-cluster != 'false'
-  #   strategy:
-  #     matrix:
-  #       image: [main, scanner, scanner-db, collector]
-  #   steps:
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - name: Wait for the ${{matrix.image}} image
-  #       uses: ./.actions/release/wait-for-image
-  #       with:
-  #         token: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
-  #         image: "rhacs-eng/${{ matrix.image }}:${{ inputs.version }}"
-  #         # Do not wait if running dry
-  #         interval: ${{ fromJSON('["30", "0"]')[env.DRY_RUN == 'true'] }}
-  #         limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[env.DRY_RUN == 'true'] }}
+  wait-for-images:
+    name: Wait for images on Quay.io
+    runs-on: ubuntu-latest
+    if: >- # Skip if no clusters are going to be created.
+      inputs.create-k8s-cluster != 'false' ||
+      inputs.create-os4-cluster != 'false' ||
+      inputs.create-long-cluster != 'false'
+    strategy:
+      matrix:
+        image: [main, scanner, scanner-db, collector]
+    steps:
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - name: Wait for the ${{matrix.image}} image
+        uses: ./.actions/release/wait-for-image
+        with:
+          token: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
+          image: "rhacs-eng/${{ matrix.image }}:${{ inputs.version }}"
+          # Do not wait if running dry
+          interval: ${{ fromJSON('["30", "0"]')[env.DRY_RUN == 'true'] }}
+          limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[env.DRY_RUN == 'true'] }}
 
-  # create-k8s-cluster:
-  #   name: Create k8s cluster
-  #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-  #   if: inputs.dry-run != 'true' && inputs.create-k8s-cluster != 'false'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: ./.actions/infra/create-cluster
-  #       with:
-  #         token: ${{ secrets.INFRA_TOKEN }}
-  #         flavor: qa-demo
-  #         name: qa-k8s-${{ inputs.version }}
-  #         args: main-image=quay.io/rhacs-eng/main:${{ inputs.version }},central-db-image=quay.io/rhacs-eng/central-db:${{ inputs.version }}
-  #         lifespan: 48h
-
-  # notify-k8s-cluster:
-  #   name: Notify about K8s cluster creation
-  #   needs: [properties, create-k8s-cluster]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     NAME: qa-k8s-${{ inputs.version }}
-  #   steps:
-  #     - name: Determine demo url and cluster name
-  #       id: get_demo_artifacts
-  #       run: |
-  #         echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
-  #         echo "url=https://${NAME//[.-]/}.demo.stackrox.com/login" >> "$GITHUB_OUTPUT"
-  #     - name: Post to Slack
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       with:
-  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
-  #         payload: >-
-  #           {
-  #             "text": "QA Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|QA demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-  #                 }
-  #               },
-  #               {
-  #                 "type": "divider"
-  #               },
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":arrow_right: When it is ready in ca. 20 minutes, a notification will be posted in #acs-infra-notifications channel, and the cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} with your @stackrox.com Google account."
-  #                 }
-  #               }
-  #             ]
-  #           }
-
-  # create-os4-cluster:
-  #   name: Create OS4 cluster
-  #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-  #   if: inputs.dry-run != 'true' && inputs.create-os4-cluster != 'false'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: ./.actions/infra/create-cluster
-  #       with:
-  #         token: ${{ secrets.INFRA_TOKEN }}
-  #         flavor: openshift-4-demo
-  #         name: openshift-4-demo-${{ inputs.version }}
-  #         args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }}
-  #         lifespan: 48h
-
-  # notify-os4-cluster:
-  #   name: Notify about Openshift cluster creation
-  #   needs: [properties, create-os4-cluster]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     NAME: openshift-4-demo-${{ inputs.version }}
-  #   steps:
-  #     - name: Determine demo url and cluster name
-  #       id: get_demo_artifacts
-  #       run: |
-  #         echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
-  #         echo "url=https://central-stackrox.apps.${NAME//./-}.openshift.infra.rox.systems/login" >> "$GITHUB_OUTPUT"
-  #     - name: Post to Slack
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       with:
-  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
-  #         payload: >-
-  #           {
-  #             "text": "Openshift 4 Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
-
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-  #                 }
-  #               },
-  #               {
-  #                 "type": "divider"
-  #               },
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":arrow_right: The cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} in ~40 minutes. You can find the admin password and kubeconfig with `infractl artifacts ${{ steps.get_demo_artifacts.outputs.cluster-name }}`."
-  #                 }
-  #               }
-  #             ]
-  #           }
-
-  debug:
-    name: debug
+  create-k8s-cluster:
+    name: Create k8s cluster
+    needs: [wait-for-images]
+    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+    if: inputs.dry-run != 'true' && inputs.create-k8s-cluster != 'false'
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "create-os4-cluster: ${{ inputs.create-os4-cluster }}"
-          echo "create-k8s-cluster: ${{ inputs.create-k8s-cluster }}"
-          echo "create-long-running-cluster: ${{ inputs.create-long-cluster }}"
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: ./.actions/infra/create-cluster
+        with:
+          token: ${{ secrets.INFRA_TOKEN }}
+          flavor: qa-demo
+          name: qa-k8s-${{ inputs.version }}
+          args: main-image=quay.io/rhacs-eng/main:${{ inputs.version }},central-db-image=quay.io/rhacs-eng/central-db:${{ inputs.version }}
+          lifespan: 48h
 
-  # create-long-running-cluster-for-fake-load:
-  #   name: Create GKE long-running cluster for fake load
-  #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-  #   if: >-
-  #     inputs.dry-run != 'true' &&
-  #     inputs.create-long-cluster != 'false'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: ./.actions/infra/create-cluster
-  #       with:
-  #         token: ${{ secrets.INFRA_TOKEN }}
-  #         flavor: gke-default
-  #         name: ${{ inputs.cluster-with-fake-load-name }}
-  #         lifespan: 168h
-  #         args: nodes=5,machine-type=e2-standard-8
-  #         wait: true
+  notify-k8s-cluster:
+    name: Notify about K8s cluster creation
+    needs: [properties, create-k8s-cluster]
+    runs-on: ubuntu-latest
+    env:
+      NAME: qa-k8s-${{ inputs.version }}
+    steps:
+      - name: Determine demo url and cluster name
+        id: get_demo_artifacts
+        run: |
+          echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
+          echo "url=https://${NAME//[.-]/}.demo.stackrox.com/login" >> "$GITHUB_OUTPUT"
+      - name: Post to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.properties.outputs.slack-channel }}
+          payload: >-
+            {
+              "text": "QA Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|QA demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":arrow_right: When it is ready in ca. 20 minutes, a notification will be posted in #acs-infra-notifications channel, and the cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} with your @stackrox.com Google account."
+                  }
+                }
+              ]
+            }
 
-  # # TODO ROX-19190 Don't DRY. Make this and the above into a separate action.
-  # create-long-running-cluster-for-real-load:
-  #   name: Create GKE long-running cluster for real load
-  #   needs: [wait-for-images]
-  #   # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-  #   if: >-
-  #     inputs.dry-run != 'true' &&
-  #     inputs.create-long-cluster != 'false'
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: ./.actions/infra/create-cluster
-  #       with:
-  #         token: ${{ secrets.INFRA_TOKEN }}
-  #         flavor: gke-default
-  #         name: ${{ inputs.cluster-with-real-load-name }}
-  #         lifespan: 168h
-  #         args: nodes=5,machine-type=e2-standard-8
-  #         wait: true
+  create-os4-cluster:
+    name: Create OS4 cluster
+    needs: [wait-for-images]
+    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+    if: inputs.dry-run != 'true' && inputs.create-os4-cluster != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: ./.actions/infra/create-cluster
+        with:
+          token: ${{ secrets.INFRA_TOKEN }}
+          flavor: openshift-4-demo
+          name: openshift-4-demo-${{ inputs.version }}
+          args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }}
+          lifespan: 48h
 
-  # start-acs:
-  #   name: Start ACS
-  #   needs: [properties, create-long-running-cluster-for-fake-load]
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     rox_password: ${{ steps.get-central-info.outputs.rox_password }}
-  #     central-ip: ${{ steps.get-central-info.outputs.central-ip }}
-  #   env:
-  #     NAME: ${{ inputs.cluster-with-fake-load-name }}
-  #     KUBECONFIG: artifacts/kubeconfig
-  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-  #   steps:
-  #     - uses: stackrox/actions/infra/install-infractl@v1
-  #     - name: Test readiness
-  #       run: |
-  #         STATUS=$(infractl get "${NAME//./-}" --json | jq -r .Status)
-  #         if [ "$STATUS" != "READY" ]; then
-  #           exit 1
-  #         fi
-  #     - name: Check out stackrox code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{inputs.version}}
-  #         repository: stackrox/stackrox
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: "google-github-actions/auth@v1"
-  #       with:
-  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-  #     - name: "Set up Cloud SDK"
-  #       uses: "google-github-actions/setup-gcloud@v1"
-  #       with:
-  #         install_components: "gke-gcloud-auth-plugin"
-  #     - name: Download artifacts
-  #       id: artifacts
-  #       run: |
-  #         infractl artifacts "${NAME//./-}" -d artifacts >> "$GITHUB_STEP_SUMMARY"
-  #     - name: Launch central
-  #       id: launch-central
-  #       uses: ./.actions/release/start-acs
-  #       with:
-  #         main-image-tag: ${{inputs.version}}
-  #         kubeconfig: ${{ env.KUBECONFIG }}
-  #         registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-  #         registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-  #         stackrox-dir: ${{ github.workspace }}
-  #         name: ${{ env.NAME }}
-  #     # TODO ROX-19190 Get this information from the previous step
-  #     - name: Get central info
-  #       id: get-central-info
-  #       run: |
-  #         CENTRAL_IP=$(kubectl -n stackrox get svc/central-loadbalancer -o json | jq -r '.status.loadBalancer.ingress[0] | .ip // .hostname')
-  #         ROX_ADMIN_PASSWORD=$(cat ${{ github.workspace }}/deploy/k8s/central-deploy/password)
-  #         echo "rox_password=${ROX_ADMIN_PASSWORD}" >> "$GITHUB_OUTPUT"
-  #         echo "central-ip=${CENTRAL_IP}" >> "$GITHUB_OUTPUT"
+  notify-os4-cluster:
+    name: Notify about Openshift cluster creation
+    needs: [properties, create-os4-cluster]
+    runs-on: ubuntu-latest
+    env:
+      NAME: openshift-4-demo-${{ inputs.version }}
+    steps:
+      - name: Determine demo url and cluster name
+        id: get_demo_artifacts
+        run: |
+          echo "cluster-name=${NAME//./-}" >> "$GITHUB_OUTPUT"
+          echo "url=https://central-stackrox.apps.${NAME//./-}.openshift.infra.rox.systems/login" >> "$GITHUB_OUTPUT"
+      - name: Post to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.properties.outputs.slack-channel }}
+          payload: >-
+            {
+              "text": "Openshift 4 Demo cluster is being created. Check #acs-infra-notifications for cluster access.",
+
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":arrow_right: The cluster will be accessible at ${{ steps.get_demo_artifacts.outputs.url }} in ~40 minutes. You can find the admin password and kubeconfig with `infractl artifacts ${{ steps.get_demo_artifacts.outputs.cluster-name }}`."
+                  }
+                }
+              ]
+            }
+
+  create-long-running-cluster-for-fake-load:
+    name: Create GKE long-running cluster for fake load
+    needs: [wait-for-images]
+    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+    if: >-
+      inputs.dry-run != 'true' &&
+      inputs.create-long-cluster != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: ./.actions/infra/create-cluster
+        with:
+          token: ${{ secrets.INFRA_TOKEN }}
+          flavor: gke-default
+          name: ${{ inputs.cluster-with-fake-load-name }}
+          lifespan: 168h
+          args: nodes=5,machine-type=e2-standard-8
+          wait: true
+
+  # TODO ROX-19190 Don't DRY. Make this and the above into a separate action.
+  create-long-running-cluster-for-real-load:
+    name: Create GKE long-running cluster for real load
+    needs: [wait-for-images]
+    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
+    if: >-
+      inputs.dry-run != 'true' &&
+      inputs.create-long-cluster != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: ./.actions/infra/create-cluster
+        with:
+          token: ${{ secrets.INFRA_TOKEN }}
+          flavor: gke-default
+          name: ${{ inputs.cluster-with-real-load-name }}
+          lifespan: 168h
+          args: nodes=5,machine-type=e2-standard-8
+          wait: true
+
+  start-acs:
+    name: Start ACS
+    needs: [properties, create-long-running-cluster-for-fake-load]
+    runs-on: ubuntu-latest
+    outputs:
+      rox_password: ${{ steps.get-central-info.outputs.rox_password }}
+      central-ip: ${{ steps.get-central-info.outputs.central-ip }}
+    env:
+      NAME: ${{ inputs.cluster-with-fake-load-name }}
+      KUBECONFIG: artifacts/kubeconfig
+      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+    steps:
+      - uses: stackrox/actions/infra/install-infractl@v1
+      - name: Test readiness
+        run: |
+          STATUS=$(infractl get "${NAME//./-}" --json | jq -r .Status)
+          if [ "$STATUS" != "READY" ]; then
+            exit 1
+          fi
+      - name: Check out stackrox code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.version}}
+          repository: stackrox/stackrox
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          install_components: "gke-gcloud-auth-plugin"
+      - name: Download artifacts
+        id: artifacts
+        run: |
+          infractl artifacts "${NAME//./-}" -d artifacts >> "$GITHUB_STEP_SUMMARY"
+      - name: Launch central
+        id: launch-central
+        uses: ./.actions/release/start-acs
+        with:
+          main-image-tag: ${{inputs.version}}
+          kubeconfig: ${{ env.KUBECONFIG }}
+          registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+          stackrox-dir: ${{ github.workspace }}
+          name: ${{ env.NAME }}
+      # TODO ROX-19190 Get this information from the previous step
+      - name: Get central info
+        id: get-central-info
+        run: |
+          CENTRAL_IP=$(kubectl -n stackrox get svc/central-loadbalancer -o json | jq -r '.status.loadBalancer.ingress[0] | .ip // .hostname')
+          ROX_ADMIN_PASSWORD=$(cat ${{ github.workspace }}/deploy/k8s/central-deploy/password)
+          echo "rox_password=${ROX_ADMIN_PASSWORD}" >> "$GITHUB_OUTPUT"
+          echo "central-ip=${CENTRAL_IP}" >> "$GITHUB_OUTPUT"
 
 
-  #     - name: Post to Slack
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       with:
-  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
-  #         payload: >-
-  #           {
-  #             "text": "Long-running cluster created. Setup your local access with `scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}`",
+      - name: Post to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.properties.outputs.slack-channel }}
+          payload: >-
+            {
+              "text": "Long-running cluster created. Setup your local access with `scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}`",
 
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":tada: *Long-running cluster `${{ inputs.cluster-with-fake-load-name }}` created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
-  #                 }
-  #               },
-  #               {
-  #                 "type": "divider"
-  #               },
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": ":arrow_right: Setup your local access to Central by running:\n```curl -L https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}```"
-  #                 }
-  #               }
-  #             ]
-  #           }
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada: *Long-running cluster `${{ inputs.cluster-with-fake-load-name }}` created for ${{ inputs.version }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":arrow_right: Setup your local access to Central by running:\n```curl -L https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}```"
+                  }
+                }
+              ]
+            }
 
-  #     - name: Start fake workload
-  #       env:
-  #         API_ENDPOINT: localhost:8000
-  #         ROX_PASSWORD: ${{ steps.get-central-info.outputs.rox_password }}
-  #       run: |
-  #         #echo "::add-mask::$ROX_PASSWORD"
-  #         kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &
-  #         sleep 20
-  #         ./scale/launch_workload.sh np-load
-  #         echo "Fake workload has been deployed to the long-running cluster" >> "$GITHUB_STEP_SUMMARY"
+      - name: Start fake workload
+        env:
+          API_ENDPOINT: localhost:8000
+          ROX_PASSWORD: ${{ steps.get-central-info.outputs.rox_password }}
+        run: |
+          #echo "::add-mask::$ROX_PASSWORD"
+          kubectl -n stackrox port-forward deploy/central 8000:8443 > /dev/null 2>&1 &
+          sleep 20
+          ./scale/launch_workload.sh np-load
+          echo "Fake workload has been deployed to the long-running cluster" >> "$GITHUB_STEP_SUMMARY"
 
-  # start-secured-cluster:
-  #   name: Start secured cluster
-  #   needs: [properties, start-acs, create-long-running-cluster-for-real-load]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
-  #     KUBECONFIG: artifacts/kubeconfig
-  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-  #   steps:
-  #     - uses: stackrox/actions/infra/install-infractl@v1
-  #     - name: Test readiness for secured cluster
-  #       run: |
-  #         STATUS=$(infractl get "${SECURED_CLUSTER_NAME//./-}" --json | jq -r .Status)
-  #         if [ "$STATUS" != "READY" ]; then
-  #           exit 1
-  #         fi
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{inputs.version}}
-  #         repository: stackrox/stackrox
-  #     - uses: "google-github-actions/auth@v1"
-  #       with:
-  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-  #     - name: "Set up Cloud SDK"
-  #       uses: "google-github-actions/setup-gcloud@v1"
-  #       with:
-  #         install_components: "gke-gcloud-auth-plugin"
-  #     - name: Download artifacts
-  #       id: artifacts
-  #       run: |
-  #         infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d artifacts
-  #     - name: Launch secured cluster
-  #       id: launch-secured-cluster
-  #       env:
-  #         MAIN_IMAGE_TAG: ${{inputs.version}} # Release version, e.g. 3.63.0-rc.2.
-  #         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-  #         ROX_ADMIN_PASSWORD: ${{ needs.start-acs.outputs.rox_password }}
-  #         ROX_ADMIN_USERNAME: admin
-  #         CENTRAL_IP: ${{ needs.start-acs.outputs.central-ip }}
-  #         CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
-  #         API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
-  #         CLUSTER: secured-cluster
-  #       run: |
-  #         "${{ github.workspace }}"/deploy/k8s/sensor.sh
-  #          kubectl -n stackrox create secret generic access-rhacs --from-literal="username=${ROX_ADMIN_USERNAME}" --from-literal="password=${ROX_ADMIN_PASSWORD}" --from-literal="central_url=https://${CENTRAL_IP}":443
+  start-secured-cluster:
+    name: Start secured cluster
+    needs: [properties, start-acs, create-long-running-cluster-for-real-load]
+    runs-on: ubuntu-latest
+    env:
+      SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
+      KUBECONFIG: artifacts/kubeconfig
+      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+    steps:
+      - uses: stackrox/actions/infra/install-infractl@v1
+      - name: Test readiness for secured cluster
+        run: |
+          STATUS=$(infractl get "${SECURED_CLUSTER_NAME//./-}" --json | jq -r .Status)
+          if [ "$STATUS" != "READY" ]; then
+            exit 1
+          fi
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.version}}
+          repository: stackrox/stackrox
+      - uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          install_components: "gke-gcloud-auth-plugin"
+      - name: Download artifacts
+        id: artifacts
+        run: |
+          infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d artifacts
+      - name: Launch secured cluster
+        id: launch-secured-cluster
+        env:
+          MAIN_IMAGE_TAG: ${{inputs.version}} # Release version, e.g. 3.63.0-rc.2.
+          REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+          ROX_ADMIN_PASSWORD: ${{ needs.start-acs.outputs.rox_password }}
+          ROX_ADMIN_USERNAME: admin
+          CENTRAL_IP: ${{ needs.start-acs.outputs.central-ip }}
+          CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
+          API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
+          CLUSTER: secured-cluster
+        run: |
+          "${{ github.workspace }}"/deploy/k8s/sensor.sh
+           kubectl -n stackrox create secret generic access-rhacs --from-literal="username=${ROX_ADMIN_USERNAME}" --from-literal="password=${ROX_ADMIN_PASSWORD}" --from-literal="central_url=https://${CENTRAL_IP}":443
 
-  # start-kube-burner:
-  #   name: Start kube-burner
-  #   needs: [properties, start-secured-cluster]
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
-  #     KUBECONFIG: ${{ github.workspace }}/artifacts/kubeconfig
-  #     INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
-  #     USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-  #   steps:
-  #     - uses: stackrox/actions/infra/install-infractl@v1
-  #     - name: Check out kube-burner config repository code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/${{ inputs.kube-burner-config-repo }}
-  #         path: .kube-burner-config
-  #         ref: ${{ inputs.kube-burner-config-ref }}
-  #     - name: Check out cloud-bulldozer/benchmark-operator code
-  #       run: |
-  #         git clone https://github.com/cloud-bulldozer/benchmark-operator.git
-  #         cd ${{ github.workspace }}/benchmark-operator
-  #         git checkout 081359d2a90ba556a603840b18015d10d05a89ec
-  #     - name: Checkout local action
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: stackrox/actions
-  #         path: .actions
-  #         ref: ${{ inputs.workflow-ref }}
-  #     - uses: "google-github-actions/auth@v1"
-  #       with:
-  #         credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
-  #     - name: "Set up Cloud SDK"
-  #       uses: "google-github-actions/setup-gcloud@v1"
-  #       with:
-  #         install_components: "gke-gcloud-auth-plugin"
-  #     - name: Download artifacts
-  #       id: artifacts
-  #       run: |
-  #         infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d ${{ github.workspace }}/artifacts
-  #     - name: Launch kube-burner
-  #       id: launch-kube-burner
-  #       env:
-  #         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-  #         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-  #       uses: ./.actions/release/start-kube-burner
-  #       with:
-  #         kube-burner-config-dir: ./.kube-burner-config/scripts/release-tools/kube-burner-configs
-  #         benchmark-operator-dir: ${{ github.workspace }}/benchmark-operator
+  start-kube-burner:
+    name: Start kube-burner
+    needs: [properties, start-secured-cluster]
+    runs-on: ubuntu-latest
+    env:
+      SECURED_CLUSTER_NAME: ${{ inputs.cluster-with-real-load-name }}
+      KUBECONFIG: ${{ github.workspace }}/artifacts/kubeconfig
+      INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
+      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+    steps:
+      - uses: stackrox/actions/infra/install-infractl@v1
+      - name: Check out kube-burner config repository code
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/${{ inputs.kube-burner-config-repo }}
+          path: .kube-burner-config
+          ref: ${{ inputs.kube-burner-config-ref }}
+      - name: Check out cloud-bulldozer/benchmark-operator code
+        run: |
+          git clone https://github.com/cloud-bulldozer/benchmark-operator.git
+          cd ${{ github.workspace }}/benchmark-operator
+          git checkout 081359d2a90ba556a603840b18015d10d05a89ec
+      - name: Checkout local action
+        uses: actions/checkout@v3
+        with:
+          repository: stackrox/actions
+          path: .actions
+          ref: ${{ inputs.workflow-ref }}
+      - uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCP_RELEASE_AUTOMATION_SA }}"
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          install_components: "gke-gcloud-auth-plugin"
+      - name: Download artifacts
+        id: artifacts
+        run: |
+          infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d ${{ github.workspace }}/artifacts
+      - name: Launch kube-burner
+        id: launch-kube-burner
+        env:
+          REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        uses: ./.actions/release/start-kube-burner
+        with:
+          kube-burner-config-dir: ./.kube-burner-config/scripts/release-tools/kube-burner-configs
+          benchmark-operator-dir: ${{ github.workspace }}/benchmark-operator
 
-  # notify-failed-clusters:
-  #   name: Notify about failed cluster creation
-  #   needs:
-  #     [
-  #       properties,
-  #       create-k8s-cluster,
-  #       create-os4-cluster,
-  #       create-long-running-cluster-for-fake-load,
-  #       create-long-running-cluster-for-real-load,
-  #     ]
-  #   if:
-  #     >- # Required as create-*-cluster jobs could be skipped while other jobs could fail.
-  #     always() && (
-  #       needs.create-k8s-cluster.result == 'failure' ||
-  #       needs.create-os4-cluster.result == 'failure' ||
-  #       needs.create-long-running-cluster-for-fake-load.result == 'failure' ||
-  #       needs.create-long-running-cluster-for-real-load.result == 'failure'
-  #     )
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Post to Slack
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       with:
-  #         channel-id: ${{ needs.properties.outputs.slack-channel }}
-  #         payload: >-
-  #           {
-  #             "text": "Couldn't create test cluster. Check <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" for details",
+  notify-failed-clusters:
+    name: Notify about failed cluster creation
+    needs:
+      [
+        properties,
+        create-k8s-cluster,
+        create-os4-cluster,
+        create-long-running-cluster-for-fake-load,
+        create-long-running-cluster-for-real-load,
+      ]
+    if:
+      >- # Required as create-*-cluster jobs could be skipped while other jobs could fail.
+      always() && (
+        needs.create-k8s-cluster.result == 'failure' ||
+        needs.create-os4-cluster.result == 'failure' ||
+        needs.create-long-running-cluster-for-fake-load.result == 'failure' ||
+        needs.create-long-running-cluster-for-real-load.result == 'failure'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.properties.outputs.slack-channel }}
+          payload: >-
+            {
+              "text": "Couldn't create test cluster. Check <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" for details",
 
-  #             "blocks": [
-  #             { "type": "section", "text": { "type": "mrkdwn", "text":
-  #             ":red_circle: *Couldn't create test clusters for ${{inputs.version}} milestone of <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*" }},
+              "blocks": [
+              { "type": "section", "text": { "type": "mrkdwn", "text":
+              ":red_circle: *Couldn't create test clusters for ${{inputs.version}} milestone of <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*" }},
 
-  #           { "type": "divider" },
+            { "type": "divider" },
 
-  #           { "type": "section", "text": { "type": "mrkdwn", "text":
-  #           ":arrow_right: *Please investigate the output of the
-  #           <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
-  #           workflow run and then restart the workflow.*" }},
+            { "type": "section", "text": { "type": "mrkdwn", "text":
+            ":arrow_right: *Please investigate the output of the
+            <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
+            workflow run and then restart the workflow.*" }},
 
-  #           { "type": "section", "text": { "type": "mrkdwn", "text":
-  #           ">
-  #           Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
-  #           Milestone: ${{inputs.version}}\n>
-  #           Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
-  #           ]}
+            { "type": "section", "text": { "type": "mrkdwn", "text":
+            ">
+            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
+            Milestone: ${{inputs.version}}\n>
+            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
+            ]}

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -9,19 +9,19 @@ on:
       create-k8s-cluster:
         description: Create a GKE demo cluster
         default: false
-        type: string
+        type: boolean
       create-os4-cluster:
         description: Create an Openshift 4 demo cluster
         default: false
-        type: string
+        type: boolean
       create-long-cluster:
         description: Create a long-running cluster on RC1
         default: false
-        type: string
+        type: boolean
       dry-run:
         description: Dry-run
         default: false
-        type: string
+        type: boolean
       workflow-ref:
         description: Ref of the called workflow
         type: string
@@ -41,7 +41,7 @@ on:
 env:
   main_branch: ${{github.event.repository.default_branch}}
   script_url: /repos/${{github.repository}}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
-  DRY_RUN: ${{ fromJSON('["true", "false"]')[inputs.dry-run != 'true'] }}
+  DRY_RUN: ${{ inputs.dry-run }}
   ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
   GH_TOKEN: ${{ github.token }}
   GH_NO_UPDATE_NOTIFIER: 1
@@ -51,7 +51,7 @@ jobs:
   properties:
     runs-on: ubuntu-latest
     outputs:
-      slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[inputs.dry-run != 'true'] }}
+      slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[inputs.dry-run != true] }}
       jira-projects: ${{ steps.fetch.outputs.jira-projects }}
     steps:
       - name: Read workflow properties file
@@ -64,9 +64,9 @@ jobs:
     name: Wait for images on Quay.io
     runs-on: ubuntu-latest
     if: >- # Skip if no clusters are going to be created.
-      inputs.create-k8s-cluster != 'false' ||
-      inputs.create-os4-cluster != 'false' ||
-      inputs.create-long-cluster != 'false'
+      inputs.create-k8s-cluster != false ||
+      inputs.create-os4-cluster != false ||
+      inputs.create-long-cluster != false
     strategy:
       matrix:
         image: [main, scanner, scanner-db, collector]
@@ -83,14 +83,13 @@ jobs:
           token: ${{secrets.QUAY_RHACS_ENG_BEARER_TOKEN}}
           image: "rhacs-eng/${{ matrix.image }}:${{ inputs.version }}"
           # Do not wait if running dry
-          interval: ${{ fromJSON('["30", "0"]')[env.DRY_RUN == 'true'] }}
-          limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[env.DRY_RUN == 'true'] }}
+          interval: ${{ fromJSON('["30", "0"]')[inputs.dry-run == true] }}
+          limit: ${{ fromJSON(format('["{0}","{1}"]', env.TIMEOUT_WAIT_FOR_IMAGES_SECONDS, 0))[inputs.dry-run == true] }}
 
   create-k8s-cluster:
     name: Create k8s cluster
     needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-    if: inputs.dry-run != 'true' && inputs.create-k8s-cluster != 'false'
+    if: inputs.dry-run != true && inputs.create-k8s-cluster != false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout local action
@@ -152,8 +151,7 @@ jobs:
   create-os4-cluster:
     name: Create OS4 cluster
     needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
-    if: inputs.dry-run != 'true' && inputs.create-os4-cluster != 'false'
+    if: inputs.dry-run == false && inputs.create-os4-cluster == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout local action
@@ -216,10 +214,9 @@ jobs:
   create-long-running-cluster-for-fake-load:
     name: Create GKE long-running cluster for fake load
     needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
     if: >-
-      inputs.dry-run != 'true' &&
-      inputs.create-long-cluster != 'false'
+      inputs.dry-run != true &&
+      inputs.create-long-cluster == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout local action
@@ -241,10 +238,9 @@ jobs:
   create-long-running-cluster-for-real-load:
     name: Create GKE long-running cluster for real load
     needs: [wait-for-images]
-    # Cannot use env.DRY_RUN here. `inputs.*` can be 'true', 'false' or empty.
     if: >-
-      inputs.dry-run != 'true' &&
-      inputs.create-long-cluster != 'false'
+      inputs.dry-run != true &&
+      inputs.create-long-cluster == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout local action

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
 # Start ACS central and secured cluster and patch it so that it can be used for the long running cluster
-# 
+#
 # When running locally there should be a kubeconfig created.
 # When running locally there are some environment variables that should be set
 #
 # export NAME=<cluster name>
 # export KUBECONFIG=/tmp/${NAME}/kubeconfig
-# 
+#
 # export MAIN_IMAGE_TAG=<tag>
 # export API_ENDPOINT=localhost:8000
 # export STORAGE=pvc # Backing storage
@@ -17,7 +17,8 @@
 # export LOAD_BALANCER=lb
 # export ROX_ADMIN_USERNAME=admin
 # export STACKROX_DIR=<stackrox dir>
-# 
+# export PAGERDUTY_INTEGRATION_KEY=<PagerDuty release engineering integration key>
+#
 # export GITHUB_OUTPUT=delete-log-github-output.txt
 # export GITHUB_STEP_SUMMARY=delete-log-start-acs.txt
 


### PR DESCRIPTION
- `github.events.inputs` in a called workflow will reference the original (calling) workflow's inputs. Therefore, no matter the value passed to the called workflow, it referenced the value set in the calling workflow's input. To counter this, explicitly use the `inputs.*` context.
- Using `inputs.*` context with proper boolean value for all parameters also means that we must use comparisons with boolean values :) 
- Passthrough of the PagerDuty integration key is missing.

Here is some background on how this is supposed to work: https://medium.com/@sohail.ra5/github-actions-passing-boolean-input-variables-to-reusable-workflow-call-42d39bf7342e. 

Example workflow runs:
- https://github.com/stackrox/test-gh-actions/actions/runs/6024806266 (RC.1 - ignore workflow run failure, again reprovisioned an existing cluster...)
- https://github.com/stackrox/test-gh-actions/actions/runs/6024792727 (RC.2 - did not create a long-running cluster despite the calling workflow's input to do so, all OK)