### PR TITLE
fix: add cluster name validation instead of chopping in create-cluster action

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -32,10 +32,10 @@ on:
         description: The repository where the kube-burner config files can be found
         type: string
       cluster-with-fake-load-name:
-        description: The name of the long running cluster where the central deployment is run with a sensor that creates its own fake workload
+        description: "The name of the long running cluster where the central deployment is run with a sensor that creates its own fake workload. Must comply to the regex: [a-z][-a-z0-9]{1,25}[a-z0-9]"
         type: string
       cluster-with-real-load-name:
-        description: The name of the long running cluster where collector is run with real workload
+        description: "The name of the long running cluster where collector is run with real workload. Must comply to the regex: [a-z][-a-z0-9]{1,25}[a-z0-9]"
         type: string
 
 env:

--- a/infra/create-cluster/README.md
+++ b/infra/create-cluster/README.md
@@ -33,6 +33,8 @@ Default value: unset
 
 Default value: unset
 
+Must comply to the regex: `[a-z][a-z0-9-]{1,25}[a-z0-9]`.
+
 #### lifespan
 
 Default value: `48h`

--- a/infra/create-cluster/action.yml
+++ b/infra/create-cluster/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: Flavor (`qa-demo`, `gke-default`, `openshift-4-demo`...)
     required: true
   name:
-    description: Cluster name ([a-z][-a-z0-9]{1,26}[a-z0-9])
+    description: Cluster name ([a-z][-a-z0-9]{1,25}[a-z0-9])
     required: true
   lifespan:
     description: Cluster lifespan

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -20,8 +20,13 @@ check_not_empty \
     FLAVOR NAME LIFESPAN WAIT \
     INFRA_TOKEN
 
+ALLOWED_NAMES="^[a-z][a-z0-9-]{1,25}[a-z0-9]$"
 CNAME="${NAME//./-}"
-CNAME="${CNAME:0:28}"
+
+if ! [[ "${CNAME}" =~ ${ALLOWED_NAMES} ]]; then
+    gh_log error "The cluster name must comply to the regular expression: \"${ALLOWED_NAMES}"\"
+    exit 1
+fi
 
 function cluster_info() {
     infractl 2>/dev/null get "$1" --json


### PR DESCRIPTION
Adapts the create-demo-clusters workflow for changes in https://github.com/stackrox/infra/pull/1016.