### PR TITLE
Jv rox 19896 long running collector should use core bpf

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -398,7 +398,7 @@ jobs:
           CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
           API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
           CLUSTER: secured-cluster
-          COLLECTION_METHOD: CORE_BPF
+          COLLECTION_METHOD: core_bpf
         run: |
           "${{ github.workspace }}"/deploy/k8s/sensor.sh
           kubectl -n stackrox create secret generic access-rhacs \

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -398,6 +398,7 @@ jobs:
           CLUSTER_API_ENDPOINT: https://${{ needs.start-acs.outputs.central-ip }}:443
           API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
           CLUSTER: secured-cluster
+          COLLECTION_METHOD: CORE_BPF
         run: |
           "${{ github.workspace }}"/deploy/k8s/sensor.sh
           kubectl -n stackrox create secret generic access-rhacs \


### PR DESCRIPTION
Title is sufficient.

## Testing

Go to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml

Click on "Run workflow".
Change branch to jv-ROX-19896-long-running-collector-should-use-core_bpf

Set version to 4.2.0-rc.1

Select "Create a long-running cluster on RC1" and "Create a GKE demo cluster"
Click run workflow.

Wait for the workflow to finish

infractl artifacts core-real-load-4-2-0-rc-1 --download-dir /tmp/artifacts-core-real-load-4-2-0-rc-1

export KUBECONFIG=/tmp/artifacts-core-real-load-4-2-0-rc-1/kubeconfig

```
ks get pod
NAME                                READY   STATUS    RESTARTS   AGE
admission-control-7cfccbc78-mln7j   1/1     Running   0          20m
admission-control-7cfccbc78-sqxkw   1/1     Running   0          20m
admission-control-7cfccbc78-zm5qk   1/1     Running   0          20m
collector-6dcxf                     2/2     Running   0          18m
collector-cxllx                     2/2     Running   0          19m
collector-dqcs6                     2/2     Running   0          19m
collector-lffjw                     2/2     Running   0          18m
collector-lp5bd                     2/2     Running   0          19m
sensor-6cd75cdb97-n7ppg             1/1     Running   0          19m
```

```
ks describe pod collector-lp5bd
Name:             collector-lp5bd
Namespace:        stackrox
Priority:         0
Service Account:  collector
Node:             gke-core-real-load-4-2-0-default-pool-339c11c4-gbms/10.100.23.230
Start Time:       Sun, 01 Oct 2023 20:58:45 -0700
Labels:           app=collector
                  app.kubernetes.io/component=collector
                  app.kubernetes.io/instance=stackrox-secured-cluster-services
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=stackrox
                  app.kubernetes.io/part-of=stackrox-secured-cluster-services
                  app.kubernetes.io/version=4.2.0-rc.1
                  controller-revision-hash=77979f776b
                  helm.sh/chart=sensor-400.2.0-rc.1
                  pod-template-generation=2
                  service=collector
Annotations:      cni.projectcalico.org/containerID: 4c26ac5cc2bf912c2979ced5c3436500917be4e88f385539e837d2df19b1c538
                  cni.projectcalico.org/podIP: 10.100.35.7/32
                  cni.projectcalico.org/podIPs: 10.100.35.7/32
                  email: support@stackrox.com
                  meta.helm.sh/release-name: stackrox-secured-cluster-services
                  meta.helm.sh/release-namespace: stackrox
                  owner: stackrox
Status:           Running
IP:               10.100.35.7
IPs:
  IP:           10.100.35.7
Controlled By:  DaemonSet/collector
Containers:
  collector:
    Container ID:   containerd://c52a2854293e998cd7d2d3af0d040ca8f2c12313a712b0adf3b3c64e5cbf2ba7
    Image:          quay.io/stackrox-io/collector:4.2.0-rc.1
    Image ID:       quay.io/stackrox-io/collector@sha256:cd03959760a7f257deaf6845b5cfe8b9bb20e22253aeeb99e09611041953c3a8
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Sun, 01 Oct 2023 20:58:46 -0700
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     750m
      memory:  1Gi
    Requests:
      cpu:     50m
      memory:  320Mi
    Environment:
      COLLECTOR_CONFIG:                           {"tlsConfig":{"caCertPath":"/var/run/secrets/stackrox.io/certs/ca.pem","clientCertPath":"/var/run/secrets/stackrox.io/certs/cert.pem","clientKeyPath":"/var/run/secrets/stackrox.io/certs/key.pem"}}
      COLLECTION_METHOD:                          CORE_BPF
```