### PR TITLE
fix: long-running cluster access script needs to run from local machine

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -337,7 +337,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":arrow_right: Setup your local access to Central by running:\n```curl -L https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/release-tools/setup-central-access.sh | bash -s -- ${{ inputs.cluster-with-fake-load-name }}```"
+                    "text": ":arrow_right: Setup your local access to Central by running:\n```./scripts/release-tools/setup-central-access.sh ${{ inputs.cluster-with-fake-load-name }}```\nfrom your local machine."
                   }
                 }
               ]


### PR DESCRIPTION
... instead of via curl.
That is because it is sourcing `lib.sh` from the same directory, which is obviously not available if only the script is downloaded.

Example error: 

```
$ curl -L https://raw.githubusercontent.com/stackrox/stackrox/master/scripts/release-tools/setup-central-access.sh | bash -s -- long-fake-load-4.2.2-rc.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   813  100   813    0     0   2944      0 --:--:-- --:--:-- --:--:--  3000
bash: line 7: ./lib.sh: No such file or directory
```

This updates the Slack notification. 