### PR TITLE
feat(infra): add no-slack input for create-cluster

### DIFF
--- a/infra/create-cluster/README.md
+++ b/infra/create-cluster/README.md
@@ -10,14 +10,15 @@ permissions: {}
 
 ## All options
 
-| Input                 | Description                               | Default   |
-| ----------------------| ------------------------------------------| --------- |
-| [token](#token)       | Infra token                               |           |
-| [flavor](#flavor)     | Cluster flavor                            |           |
-| [name](#name)         | Cluster name                              |           |
-| [lifespan](#lifespan) | Lifespan                                  | `48h`     |
-| [args](#args)         | Arguments                                 |           |
-| [wait](#wait)         | Whether to wait for the cluster readiness | `'false'` |
+| Input                 | Description                                                    | Default   |
+|-----------------------|----------------------------------------------------------------|-----------|
+| [token](#token)       | Infra token                                                    |           |
+| [flavor](#flavor)     | Cluster flavor                                                 |           |
+| [name](#name)         | Cluster name                                                   |           |
+| [lifespan](#lifespan) | Lifespan                                                       | `48h`     |
+| [args](#args)         | Arguments                                                      |           |
+| [wait](#wait)         | Whether to wait for the cluster readiness                      | `'false'` |
+| [no-slack](#no-slack) | Whether to to skip sending Slack messages for lifecycle events | `'false'` |
 
 ### Detailed options
 
@@ -44,6 +45,10 @@ Default value: `48h`
 Default value: unset
 
 #### wait
+
+Default value: `'false'`
+
+#### no-slack
 
 Default value: `'false'`
 

--- a/infra/create-cluster/action.yml
+++ b/infra/create-cluster/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Whether to wait for the cluster readiness
     required: false
     default: "false"
+  no-slack:
+    description: Whether to skip sending Slack messages for lifecycle events
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -48,4 +52,5 @@ runs:
           "${{ inputs.name }}" \
           "${{ inputs.lifespan }}" \
           "${{ inputs.wait }}" \
+          "${{ inputs.no-slack }}" \
           "${{ inputs.args }}"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -9,9 +9,10 @@ FLAVOR="$1"
 NAME="$2"
 LIFESPAN="$3"
 WAIT="$4"
+NO_SLACK="$5"
 
-if [ "$#" -gt 4 ]; then
-    ARGS="$5"
+if [ "$#" -gt 5 ]; then
+    ARGS="$6"
 else
     ARGS=""
 fi
@@ -96,6 +97,11 @@ OPTIONS=()
 if [ "$WAIT" = "true" ]; then
     OPTIONS+=("--wait")
     gh_log warning "The job will wait for the cluster creation to finish."
+fi
+
+if [ "$NO_SLACK" = "true" ]; then
+    OPTIONS+=("--no-slack")
+    gh_log notice "Skipping sending Slack messages for cluster \`$CNAME\`."
 fi
 
 IFS=',' read -ra args <<<"$ARGS"


### PR DESCRIPTION
# Description

This adds the `--no-slack` input for the `create-cluster` action.

Reason for this was simply to reduce unwanted noise when spinning up clusters via this action.