### PR TITLE
ROX-20315: collection_method on 3.x releases should be KERNEL_MODULE

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -400,7 +400,13 @@ jobs:
           CLUSTER: secured-cluster
           COLLECTION_METHOD: core_bpf
         run: |
-          "${{ github.workspace }}"/deploy/k8s/sensor.sh
+          # Overriding COLLECTION_METHOD for 3.x releases because 'core_bpf' was introduced in 4.1.0
+          # 4.0 is already out of support
+          # TODO(ROX-20631): remove the override after 3.74 is out of support
+          if [[ "${MAIN_IMAGE_TAG}" == 3.* ]]; then
+            COLLECTION_METHOD="KERNEL_MODULE"
+          fi
+          "${{ github.workspace }}/deploy/k8s/sensor.sh"
           kubectl -n stackrox create secret generic access-rhacs \
             --from-literal="username=${ROX_ADMIN_USERNAME}" \
             --from-literal="password=${ROX_ADMIN_PASSWORD}" \

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -404,7 +404,7 @@ jobs:
           # 4.0 is already out of support
           # TODO(ROX-20631): remove the override after 3.74 is out of support
           if [[ "${MAIN_IMAGE_TAG}" == 3.* ]]; then
-            COLLECTION_METHOD="KERNEL_MODULE"
+            export COLLECTION_METHOD="KERNEL_MODULE"
           fi
           "${{ github.workspace }}/deploy/k8s/sensor.sh"
           kubectl -n stackrox create secret generic access-rhacs \

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -404,7 +404,7 @@ jobs:
           # 4.0 is already out of support
           # TODO(ROX-20631): remove the override after 3.74 is out of support
           if [[ "${MAIN_IMAGE_TAG}" == 3.* ]]; then
-            export COLLECTION_METHOD="KERNEL_MODULE"
+            export COLLECTION_METHOD="kernel-module"
           fi
           "${{ github.workspace }}/deploy/k8s/sensor.sh"
           kubectl -n stackrox create secret generic access-rhacs \


### PR DESCRIPTION
Tests [create-clusters.yml](https://github.com/stackrox/test-gh-actions/blob/main/.github/workflows/create-clusters.yml) workflow and confirmed by looking at collector pods. 

| RC | expected COLLECTION_METHOD | Run | Log output | confirmed in pod |
|---|---|---|---|--|
| 3.74.7-rc.1 | `KERNEL_MODULE` | https://github.com/stackrox/test-gh-actions/actions/runs/6746286591/job/18340725612 (failed because https://github.com/stackrox/stackrox/pull/8307 was merged after 3.74.7-rc.1) | `COLLECTION_METHOD set to kernel-module` | ✅  |
| 4.2.2-rc.1 | `core_bpf` | https://github.com/stackrox/test-gh-actions/actions/runs/6746608901 | `COLLECTION_METHOD set to core_bpf` | ✅  |

