### PR TITLE
ROX-21548: Long running collector should be monitored

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -399,6 +399,7 @@ jobs:
           API_ENDPOINT: ${{ needs.start-acs.outputs.central-ip }}:443
           CLUSTER: secured-cluster
           COLLECTION_METHOD: core_bpf
+          MONITORING_SUPPORT: "true"
         run: |
           # Overriding COLLECTION_METHOD for 3.x releases because 'core_bpf' was introduced in 4.1.0
           # 4.0 is already out of support

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -426,9 +426,6 @@ jobs:
           envsubst < "${COMMON_DIR}/../charts/monitoring/values.yaml" > "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
           helm upgrade -n stackrox --install --create-namespace stackrox-monitoring "${COMMON_DIR}/../charts/monitoring" --values "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml" "${helm_args[@]}"
           rm "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
-
-          kubectl create -f ${{ github.workspace }}/deploy/charts/monitoring/templates/prometheus-role.yaml
-
           echo "Deployed Monitoring..."
 
 

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -426,6 +426,9 @@ jobs:
           envsubst < "${COMMON_DIR}/../charts/monitoring/values.yaml" > "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
           helm upgrade -n stackrox --install --create-namespace stackrox-monitoring "${COMMON_DIR}/../charts/monitoring" --values "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml" "${helm_args[@]}"
           rm "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
+
+          kubectl create -f ${{ github.workspace }}/deploy/charts/monitoring/templates/prometheus-role.yaml
+
           echo "Deployed Monitoring..."
 
 

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{inputs.version}}
+          ref: jv-ROX-21548-long-running-collector-should-be-monitored
           repository: stackrox/stackrox
       - uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -400,6 +400,9 @@ jobs:
           CLUSTER: secured-cluster
           COLLECTION_METHOD: core_bpf
           MONITORING_SUPPORT: "true"
+          STORAGE: pvc
+          MONITORING_LOAD_BALANCER: none
+          COMMON_DIR: ${{ github.workspace }}/deploy/common
         run: |
           # Overriding COLLECTION_METHOD for 3.x releases because 'core_bpf' was introduced in 4.1.0
           # 4.0 is already out of support
@@ -412,6 +415,20 @@ jobs:
             --from-literal="username=${ROX_ADMIN_USERNAME}" \
             --from-literal="password=${ROX_ADMIN_PASSWORD}" \
             --from-literal="central_url=${CLUSTER_API_ENDPOINT}"
+
+          echo "Deploying Monitoring..."
+          helm_args=(
+            --set persistence.type="${STORAGE}"
+            --set exposure.type="${MONITORING_LOAD_BALANCER}"
+          )
+         
+          helm dependency update "${COMMON_DIR}/../charts/monitoring"
+          envsubst < "${COMMON_DIR}/../charts/monitoring/values.yaml" > "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
+          helm upgrade -n stackrox --install --create-namespace stackrox-monitoring "${COMMON_DIR}/../charts/monitoring" --values "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml" "${helm_args[@]}"
+          rm "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
+          echo "Deployed Monitoring..."
+
+
 
   start-kube-burner:
     name: Start kube-burner


### PR DESCRIPTION
Turns on monitoring for the secured cluster with real load created by kube-burner. There is a related PR which adds the Prometheus configuration files needed to monitor CPU and memory usage and adds panels to a Grafana dashboard to display the CPU and memory usage 

https://github.com/stackrox/stackrox/pull/9573