### PR TITLE
Bumps docker/login-action to v3 to fix NodeJS warnings

### DIFF
--- a/images/retag-and-push/action.yml
+++ b/images/retag-and-push/action.yml
@@ -32,7 +32,7 @@ runs:
         registry="${dst_image%%/*}"
         echo "registry=$registry" >> $GITHUB_OUTPUT
 
-    - uses: docker/login-action@v2
+    - uses: docker/login-action@v3
       if: inputs.password != '' && inputs.username != ''
       with:
         registry: ${{ steps.get-registry-name.outputs.registry }}


### PR DESCRIPTION
In collector repo we've noticed some NodeJS warnings for a bunch of the actions we're using, including the retag-and-push action. This PR simply updates the docker/login-action version (v2 -> v3) to fix this warning.

I've had a cursory glance at other actions in this repo and I believe that this one is the only one affected.