### PR TITLE
infra/create-cluster: add --endpoint and --insecure options

### DIFF
--- a/infra/create-cluster/README.md
+++ b/infra/create-cluster/README.md
@@ -10,15 +10,17 @@ permissions: {}
 
 ## All options
 
-| Input                 | Description                                                    | Default   |
-|-----------------------|----------------------------------------------------------------|-----------|
-| [token](#token)       | Infra token                                                    |           |
-| [flavor](#flavor)     | Cluster flavor                                                 |           |
-| [name](#name)         | Cluster name                                                   |           |
-| [lifespan](#lifespan) | Lifespan                                                       | `48h`     |
-| [args](#args)         | Arguments                                                      |           |
-| [wait](#wait)         | Whether to wait for the cluster readiness                      | `'false'` |
-| [no-slack](#no-slack) | Whether to to skip sending Slack messages for lifecycle events | `'false'` |
+| Input                 | Description                                                    | Default             |
+|-----------------------|----------------------------------------------------------------|---------------------|
+| [token](#token)       | Infra token                                                    |                     |
+| [flavor](#flavor)     | Cluster flavor                                                 |                     |
+| [name](#name)         | Cluster name                                                   |                     |
+| [lifespan](#lifespan) | Lifespan                                                       | `48h`               |
+| [args](#args)         | Arguments                                                      |                     |
+| [wait](#wait)         | Whether to wait for the cluster readiness                      | `'false'`           |
+| [no-slack](#no-slack) | Whether to to skip sending Slack messages for lifecycle events | `'false'`           |
+| [endpoint](#endpoint) | URL to infra deployment                                        | `infra.rox.systems` |
+| [insecure](#insecure) | Whether to allow insecure connections to infra deployment      | `'false'`           |
 
 ### Detailed options
 
@@ -52,6 +54,14 @@ Default value: `'false'`
 
 Default value: `'false'`
 
+#### endpoint
+
+Default value: `infra.rox.systems`
+
+#### insecure
+
+Default value: `'false'`
+
 ## Usage
 
 ```yaml
@@ -69,4 +79,6 @@ jobs:
         lifespan: 48h
         args: main-image=quay.io/rhacs-eng/main:3.75.4
         wait: "false"
+        endpoint: localhost:8443
+        insecure: "true"
 ```

--- a/infra/create-cluster/action.yml
+++ b/infra/create-cluster/action.yml
@@ -26,6 +26,14 @@ inputs:
     description: Whether to skip sending Slack messages for lifecycle events
     required: false
     default: "false"
+  endpoint:
+    description: URL to infra deployment
+    required: false
+    default: infra.rox.systems
+  insecure:
+    description: Whether to allow insecure connections to infra deployment
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -53,4 +61,6 @@ runs:
           "${{ inputs.lifespan }}" \
           "${{ inputs.wait }}" \
           "${{ inputs.no-slack }}" \
+          "${{ inputs.endpoint }}" \
+          "${{ inputs.insecure }}" \
           "${{ inputs.args }}"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -3,7 +3,7 @@
 # Creates a cluster on infra.
 #
 
-set -euo pipefail
+set -euxo pipefail
 
 FLAVOR="$1"
 NAME="$2"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -10,9 +10,11 @@ NAME="$2"
 LIFESPAN="$3"
 WAIT="$4"
 NO_SLACK="$5"
+ENDPOINT="$6"
+INSECURE="$7"
 
-if [ "$#" -gt 5 ]; then
-    ARGS="$6"
+if [ "$#" -gt 7 ]; then
+    ARGS="$8"
 else
     ARGS=""
 fi
@@ -29,8 +31,17 @@ if ! [[ "${CNAME}" =~ ${ALLOWED_NAMES} ]]; then
     exit 1
 fi
 
+function infractl_call() {
+    local options=("--endpoint $ENDPOINT")
+    if [ "$INSECURE" = "true"]; then
+        options+=("--insecure")
+        gh_log notice "Using an insecure connection when connecting to infra endpoint $ENDPOINT."
+    fi
+    infractl "${options[@]}" $@
+}
+
 function cluster_info() {
-    infractl 2>/dev/null get "$1" --json
+    infractl_call 2>/dev/null get "$1" --json
 }
 
 function cluster_status() {
@@ -110,7 +121,7 @@ for arg in "${args[@]}"; do
     OPTIONS+=("$arg")
 done
 
-infractl create "$FLAVOR" "$CNAME" \
+infractl_call create "$FLAVOR" "$CNAME" \
     --lifespan "$LIFESPAN" \
     "${OPTIONS[@]}"
 

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -3,7 +3,7 @@
 # Creates a cluster on infra.
 #
 
-set -exuo pipefail
+set -euo pipefail
 
 FLAVOR="$1"
 NAME="$2"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -32,12 +32,12 @@ if ! [[ "${CNAME}" =~ ${ALLOWED_NAMES} ]]; then
 fi
 
 function infractl_call() {
-    local options=("--endpoint $ENDPOINT")
+    local options=("--endpoint" "$ENDPOINT")
     if [ "$INSECURE" = "true" ]; then
         options+=("--insecure")
         gh_log notice "Using an insecure connection when connecting to infra endpoint $ENDPOINT."
     fi
-    infractl "${options[@]}" $@
+    infractl "${options[@]}" "$@"
 }
 
 function cluster_info() {

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -32,12 +32,12 @@ if ! [[ "${CNAME}" =~ ${ALLOWED_NAMES} ]]; then
 fi
 
 function infractl_call() {
-    local options=("--endpoint" "$ENDPOINT")
+    local endpoint_options=("--endpoint" "$ENDPOINT")
     if [ "$INSECURE" = "true" ]; then
-        options+=("--insecure")
+        endpoint_options+=("--insecure")
         gh_log notice "Using an insecure connection when connecting to infra endpoint $ENDPOINT."
     fi
-    infractl "${options[@]}" "$@"
+    infractl "${endpoint_options[@]}" "$@"
 }
 
 function cluster_info() {

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -3,7 +3,7 @@
 # Creates a cluster on infra.
 #
 
-set -euxo pipefail
+set -euo pipefail
 
 FLAVOR="$1"
 NAME="$2"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -33,7 +33,7 @@ fi
 
 function infractl_call() {
     local options=("--endpoint $ENDPOINT")
-    if [ "$INSECURE" = "true"]; then
+    if [ "$INSECURE" = "true" ]; then
         options+=("--insecure")
         gh_log notice "Using an insecure connection when connecting to infra endpoint $ENDPOINT."
     fi

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -3,7 +3,7 @@
 # Creates a cluster on infra.
 #
 
-set -euo pipefail
+set -exuo pipefail
 
 FLAVOR="$1"
 NAME="$2"


### PR DESCRIPTION
Required for smoke tests on infra PR cluster.

Tested in https://github.com/stackrox/infra/pull/1203, example: https://github.com/stackrox/infra/actions/runs/8156066579/job/22292895422

Test for using default values is done in `test-infra-create-cluster` job (https://github.com/stackrox/actions/actions/runs/8157456713/job/22297178612?pr=48#step:3:13 - see endpoint and insecure options in the task call). 