### PR TITLE
ROX-27171: Make demo clusters use quay.io/rhacs-eng images

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -165,7 +165,7 @@ jobs:
           token: ${{ secrets.INFRA_TOKEN }}
           flavor: openshift-4-demo
           name: openshift-4-demo-${{ inputs.version }}
-          args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }}
+          args: central-services-helm-chart-version=${{ inputs.version }},secured-cluster-services-helm-chart-version=${{ inputs.version }},image-registry=quay.io/rhacs-eng
           lifespan: 48h
 
   notify-os4-cluster:
@@ -421,7 +421,7 @@ jobs:
             --set persistence.type="${STORAGE}"
             --set exposure.type="${MONITORING_LOAD_BALANCER}"
           )
-         
+
           helm dependency update "${COMMON_DIR}/../charts/monitoring"
           envsubst < "${COMMON_DIR}/../charts/monitoring/values.yaml" > "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml"
           helm upgrade -n stackrox --install --create-namespace stackrox-monitoring "${COMMON_DIR}/../charts/monitoring" --values "${COMMON_DIR}/../charts/monitoring/values_substituted.yaml" "${helm_args[@]}"

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -386,9 +386,16 @@ jobs:
         id: artifacts
         run: |
           infractl artifacts "${SECURED_CLUSTER_NAME//./-}" -d artifacts
+      - name: Docker login to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       - name: Launch secured cluster
         id: launch-secured-cluster
         env:
+          ROX_PRODUCT_BRANDING: RHACS_BRANDING
           MAIN_IMAGE_TAG: ${{inputs.version}} # Release version, e.g. 3.63.0-rc.2.
           REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -33,8 +33,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Docker login to quay.io
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        REGISTRY_USERNAME: ${{ inputs.registry-username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+
     - id: launch-central
       env:
+        # ROX_IMAGE_FLAVOR: rhacs not required, development_build default is quay.io/rhacs-eng, rhacs would be registry.redhat.io?
         ROX_PRODUCT_BRANDING: RHACS_BRANDING
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -37,8 +37,8 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: quay.io
-        REGISTRY_USERNAME: ${{ inputs.registry-username }}
-        REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+        username: ${{ inputs.registry-username }}
+        password: ${{ inputs.registry-password }}
 
     - id: launch-central
       env:

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -42,7 +42,6 @@ runs:
 
     - id: launch-central
       env:
-        # ROX_IMAGE_FLAVOR: rhacs not required, development_build default is quay.io/rhacs-eng, rhacs would be registry.redhat.io?
         ROX_PRODUCT_BRANDING: RHACS_BRANDING
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -41,7 +41,7 @@ runs:
         STORAGE: pvc # Backing storage
         STORAGE_CLASS: faster # Runs on an SSD type
         STORAGE_SIZE: "100" # 100G
-        MONITORING_SUPPORT: "true" # Runs monitoring
+        MONITORING_SUPPORT: "false" # Runs monitoring
         LOAD_BALANCER: lb
         ROX_ADMIN_USERNAME: admin
         PAGERDUTY_INTEGRATION_KEY: ${{ inputs.pagerduty-integration-key }}

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -36,6 +36,7 @@ runs:
     - id: launch-central
       env:
         ROX_PRODUCT_BRANDING: RHACS_BRANDING
+        ROX_IMAGE_FLAVOR: rhacs
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000
         STORAGE: pvc # Backing storage

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -48,7 +48,7 @@ runs:
         STORAGE: pvc # Backing storage
         STORAGE_CLASS: faster # Runs on an SSD type
         STORAGE_SIZE: "100" # 100G
-        MONITORING_SUPPORT: "false" # Runs monitoring
+        MONITORING_SUPPORT: "true" # Runs monitoring
         LOAD_BALANCER: lb
         ROX_ADMIN_USERNAME: admin
         PAGERDUTY_INTEGRATION_KEY: ${{ inputs.pagerduty-integration-key }}

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -36,7 +36,6 @@ runs:
     - id: launch-central
       env:
         ROX_PRODUCT_BRANDING: RHACS_BRANDING
-        ROX_IMAGE_FLAVOR: rhacs
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000
         STORAGE: pvc # Backing storage

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -35,6 +35,7 @@ runs:
   steps:
     - id: launch-central
       env:
+        ROX_IMAGE_FLAVOR: RHACS_BRANDING
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000
         STORAGE: pvc # Backing storage

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - id: launch-central
       env:
-        ROX_IMAGE_FLAVOR: RHACS_BRANDING
+        ROX_PRODUCT_BRANDING: RHACS_BRANDING
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}
         API_ENDPOINT: localhost:8000
         STORAGE: pvc # Backing storage

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -8,8 +8,7 @@
 # export NAME=<cluster name>
 # export KUBECONFIG=/tmp/${NAME}/kubeconfig
 #
-# export ROX_PRODUCT_BRANDING=RHACS_BRANDING
-# export ROX_IMAGE_FLAVOR=rhacs
+# export ROX_IMAGE_FLAVOR=RHACS_BRANDING
 # export MAIN_IMAGE_TAG=<tag>
 # export API_ENDPOINT=localhost:8000
 # export STORAGE=pvc # Backing storage
@@ -25,9 +24,6 @@
 # export GITHUB_STEP_SUMMARY=delete-log-start-acs.txt
 
 set -euo pipefail
-
-echo "${ROX_PRODUCT_BRANDING}"
-echo "${ROX_IMAGE_FLAVOR}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -8,7 +8,8 @@
 # export NAME=<cluster name>
 # export KUBECONFIG=/tmp/${NAME}/kubeconfig
 #
-# export ROX_IMAGE_FLAVOR=RHACS_BRANDING
+# export ROX_PRODUCT_BRANDING=RHACS_BRANDING
+# export ROX_IMAGE_FLAVOR=rhacs
 # export MAIN_IMAGE_TAG=<tag>
 # export API_ENDPOINT=localhost:8000
 # export STORAGE=pvc # Backing storage
@@ -24,6 +25,9 @@
 # export GITHUB_STEP_SUMMARY=delete-log-start-acs.txt
 
 set -euo pipefail
+
+echo "${ROX_PRODUCT_BRANDING}"
+echo "${ROX_IMAGE_FLAVOR}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -8,6 +8,7 @@
 # export NAME=<cluster name>
 # export KUBECONFIG=/tmp/${NAME}/kubeconfig
 #
+# export ROX_IMAGE_FLAVOR=RHACS_BRANDING
 # export MAIN_IMAGE_TAG=<tag>
 # export API_ENDPOINT=localhost:8000
 # export STORAGE=pvc # Backing storage


### PR DESCRIPTION
## What

This PR changes 
* `openshift-4-demo` cluster
* long-running cluster

to use `quay.io/rhacs-eng` images.

This workflow is used in https://github.com/stackrox/test-gh-actions/blob/main/.github/workflows/create-clusters.yml to create demo clusters for release candidates. 
The `qa-demo` cluster is already using `quay.io/rhacs-eng` images: https://github.com/stackrox/actions/blob/main/.github/workflows/create-demo-clusters.yml#L106.

## Why

`quay.io/rhacs-eng` images will be built by Konflux on release branches in the future and we want them in the demo clusters.

## Validation

* Creating demo clusters with manually dispatched workflow in test-gh-actions repository: 
  * Long-running cluster: 
    * https://github.com/stackrox/test-gh-actions/actions/runs/12137041350
    * https://infra.rox.systems/cluster/long-fake-load-4-5-5-rc-2
    * https://infra.rox.systems/cluster/long-real-load-4-5-5-rc-2
  * OCP 4 Demo: 
    * https://github.com/stackrox/test-gh-actions/actions/runs/12122885143/job/33797131698
    * https://infra.rox.systems/cluster/openshift-4-demo-4-5-5-rc-1
* Logging in to ACS Console and checking on `Workload CVEs` view, `Images` tab that no images from `quay.io/stackrox-io` are used. If you have configured kubectl to point to the demo clusters,  you can also do it like 

```
$ kubectl get pods -n stackrox -o jsonpath="{.items[*].spec['initContainers', 'containers'][*].image}" |\             
tr -s '[[:space:]]' '\n' |\
sort |\
uniq -c
```

## Rollout

Will happen automatically to all current, past and future release branches once we forward the `v1` in this repository to the merge commit.