### PR TITLE
ROX-28479: Enable external ips in long running cluster

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -270,7 +270,6 @@ jobs:
       KUBECONFIG: artifacts/kubeconfig
       INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-      ROX_EXTERNAL_IPS: "true"
     steps:
       - uses: stackrox/actions/infra/install-infractl@v1
       - name: Test readiness

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -270,6 +270,7 @@ jobs:
       KUBECONFIG: artifacts/kubeconfig
       INFRA_TOKEN: ${{secrets.INFRA_TOKEN}}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+      ROX_EXTERNAL_IPS: "true"
     steps:
       - uses: stackrox/actions/infra/install-infractl@v1
       - name: Test readiness

--- a/release/start-acs/patch-central.json
+++ b/release/start-acs/patch-central.json
@@ -8,7 +8,9 @@
                         "env": [
                             {
                                 "name": "MUTEX_WATCHDOG_TIMEOUT_SECS",
-                                "value": "0"
+                                "value": "0",
+                                "name": "ROX_EXTERNAL_IPS",
+                                "value": "true"
                             }
                         ],
                         "resources": {


### PR DESCRIPTION
A recent [PR](https://github.com/stackrox/stackrox/pull/14574) added external IPs to the fake workload generation. The purpose of this is to find bugs that might cause crashes, scalability issues, and leaks in the external IPs feature. However, the external IPs feature is off by default and is enabled by setting `ROX_EXTERNAL_IPS` to true. Currently this environment variable is not set in the long running cluster. To better detect problems with the external IPs feature it should be enabled in the long running cluster. A long running cluster was created for the PR linked to above and `ROX_EXTERNAL_IPS` was set in that cluster manually.

### Testing

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml

Clicked on `Run worflow`

Set the branch to jv-ROX-28479-enable-external-ips-in-long-running-cluster

Set the version to 0.0.3

Checked "Create a long-running cluster on RC1"

Clicked "Run workflow"

When the workflow finished

```
infractl artifacts long-fake-load-0-0-3 --download-dir /tmp/artifacts-long-fake-load-0-0-3
export KUBECONFIG=/tmp/artifacts-long-fake-load-0-0-3/kubeconfig
```

Checked the environment variable

```
ks get deployment central -o yaml
```

```
      containers:
      - command:
        - /stackrox/central-entrypoint.sh
        env:
        - name: ROX_EXTERNAL_IPS
          value: "true"
        - name: ROX_MEMLIMIT
          valueFrom:
            resourceFieldRef:
              divisor: "0"
              resource: limits.memory
```