### PR TITLE
ROX-28665: Save metrics from long running clusters to Elasticsearch

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -309,6 +309,9 @@ jobs:
           pagerduty-integration-key: ${{ secrets.RELEASE_MANAGEMENT_PAGERDUTY_INTEGRATION_KEY }}
           registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+          elasticsearch-url: ${{ secrets.K6_ELASTICSEARCH_URL }}
+          elasticsearch-user: ${{ secrets.K6_ELASTICSEARCH_USER }}
+          elasticsearch-password: ${{ secrets.K6_ELASTICSEARCH_PASSWORD }}
           stackrox-dir: ${{ github.workspace }}
           name: ${{ env.NAME }}
 

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -21,6 +21,18 @@ inputs:
     description: The password used for the docker registry
     required: true
     default: ""
+  elasticsearch-url:
+    description: The url of the Elasticsearch instance that the metrics are sent to
+    required: false
+    default: ""
+  elasticsearch-user:
+    description: The username for the Elasticsearch instance
+    required: false
+    default: ""
+  elasticsearch-password:
+    description: The password for the Elasticsearch instance
+    required: false
+    default: ""
   stackrox-dir:
     description: Where the stackrox directory is located
     required: true
@@ -46,6 +58,9 @@ runs:
         PAGERDUTY_INTEGRATION_KEY: ${{ inputs.pagerduty-integration-key }}
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
         REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+        ELASTICSEARCH_URL: ${{ inputs.elasticsearch-url }}
+        ELASTICSEARCH_USER: ${{ inputs.elasticsearch-user }}
+        ELASTICSEARCH_PASSWORD: ${{ inputs.elasticsearch-password }}
         KUBECONFIG: ${{ inputs.kubeconfig }}
         STACKROX_DIR: ${{ inputs.stackrox-dir }}
         NAME: ${{ inputs.name }}


### PR DESCRIPTION
We want to save data from the long running clusters, so long running clusters from different releases can be saved. This simply takes the Elasticsearch secrets and saves them to environment variables so that the deploy scripts will set the helmchart values such that Prometheus will send metrics to Elasticsearch.