### PR TITLE
fix: add description field infra cluster create

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -231,6 +231,7 @@ jobs:
           flavor: gke-default
           name: ${{ inputs.cluster-with-fake-load-name }}
           lifespan: 168h
+          description: "Long-running cluster (fake load) for testing ${{ inputs.version }}"
           args: nodes=5,machine-type=e2-standard-8
           wait: true
 
@@ -255,6 +256,7 @@ jobs:
           flavor: gke-default
           name: ${{ inputs.cluster-with-real-load-name }}
           lifespan: 168h
+          description: "Long-running cluster (real load) for testing ${{ inputs.version }}"
           args: nodes=5,machine-type=e2-standard-8
           wait: true
 

--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -231,7 +231,7 @@ jobs:
           flavor: gke-default
           name: ${{ inputs.cluster-with-fake-load-name }}
           lifespan: 168h
-          description: "Long-running cluster (fake load) for testing ${{ inputs.version }}"
+          description: "Long-running cluster with fake workload (no Collector) for testing ${{ inputs.version }}"
           args: nodes=5,machine-type=e2-standard-8
           wait: true
 
@@ -256,7 +256,7 @@ jobs:
           flavor: gke-default
           name: ${{ inputs.cluster-with-real-load-name }}
           lifespan: 168h
-          description: "Long-running cluster (real load) for testing ${{ inputs.version }}"
+          description: "Long-running cluster with real workload (with Collector and Berserker) for testing ${{ inputs.version }}"
           args: nodes=5,machine-type=e2-standard-8
           wait: true
 

--- a/infra/create-cluster/README.md
+++ b/infra/create-cluster/README.md
@@ -20,7 +20,8 @@ permissions: {}
 | [wait](#wait)         | Whether to wait for the cluster readiness                      | `'false'`           |
 | [no-slack](#no-slack) | Whether to to skip sending Slack messages for lifecycle events | `'false'`           |
 | [endpoint](#endpoint) | URL to infra deployment                                        | `infra.rox.systems` |
-| [insecure](#insecure) | Whether to allow insecure connections to infra deployment      | `'false'`           |
+| [insecure](#insecure) | Whether to allow insecure connections to infra deployment      | `'false'
+| [description](#description) | Cluster description text      | `''` `           |
 
 ### Detailed options
 
@@ -62,6 +63,10 @@ Default value: `infra.rox.systems`
 
 Default value: `'false'`
 
+#### description
+
+Default value: `''`
+
 ## Usage
 
 ```yaml
@@ -81,4 +86,5 @@ jobs:
         wait: "false"
         endpoint: localhost:8443
         insecure: "true"
+        description: This is my test cluster
 ```

--- a/infra/create-cluster/action.yml
+++ b/infra/create-cluster/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Whether to allow insecure connections to infra deployment
     required: false
     default: "false"
+  description:
+    description: Cluster description text
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -63,4 +67,5 @@ runs:
           "${{ inputs.no-slack }}" \
           "${{ inputs.endpoint }}" \
           "${{ inputs.insecure }}" \
+          "${{ inputs.description }}" \
           "${{ inputs.args }}"

--- a/infra/create-cluster/create-cluster.sh
+++ b/infra/create-cluster/create-cluster.sh
@@ -12,9 +12,10 @@ WAIT="$4"
 NO_SLACK="$5"
 ENDPOINT="$6"
 INSECURE="$7"
+DESCRIPTION="${8}"
 
-if [ "$#" -gt 7 ]; then
-    ARGS="$8"
+if [ "$#" -gt 8 ]; then
+    ARGS="$9"
 else
     ARGS=""
 fi
@@ -123,6 +124,7 @@ done
 
 infractl_call create "$FLAVOR" "$CNAME" \
     --lifespan "$LIFESPAN" \
+    --description "$DESCRIPTION" \
     "${OPTIONS[@]}"
 
 infra_status_summary "$CNAME" "Cluster creation has been requested"


### PR DESCRIPTION
This is helpful if we use a cryptic name for the cluster if otherwise the name would be too long. 