### PR TITLE
add pagerduty env var to sec cluster

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -406,6 +406,7 @@ jobs:
         with:
           main-image-tag: ${{inputs.version}}
           kubeconfig: ${{ env.KUBECONFIG }}
+          pagerduty-integration-key: ${{ secrets.RELEASE_MANAGEMENT_PAGERDUTY_INTEGRATION_KEY }}
           registry-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           registry-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
           rox-admin-password: ${{ needs.start-acs.outputs.rox-password }}

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: ""
   pagerduty-integration-key:
-    description: The key that will be used to send pager duty allerts
+    description: The key that will be used to send pager duty alerts
     required: false
     default: ""
   registry-username:

--- a/release/start-secured-cluster/action.yml
+++ b/release/start-secured-cluster/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: The kubeconfig file used to connect to kubernetes
     required: true
     default: ""
+  pagerduty-integration-key:
+    description: The key that will be used to send pager duty alerts
+    required: false
+    default: ""
   registry-username:
     description: The username used for the docker registry
     required: true
@@ -44,6 +48,7 @@ runs:
         REGISTRY_PASSWORD: ${{ inputs.registry-password }}
         ROX_ADMIN_PASSWORD: ${{ inputs.rox-admin-password }}                      
         ROX_ADMIN_USERNAME: admin
+        PAGERDUTY_INTEGRATION_KEY: ${{ inputs.pagerduty-integration-key }}
         CENTRAL_IP: ${{ inputs.central-ip }}                                
         CLUSTER_API_ENDPOINT: https://${{ inputs.central-ip }}:443          
         API_ENDPOINT: ${{ inputs.central-ip }}:443                          


### PR DESCRIPTION
`stackrox-monitoring-alertmanager-0` pod was crash looping in long running real load cluster due to a null pager duty key in configmap.

This change pushes the pager duty env var through the action chain so that it can be substituted into the helm values here:

https://github.com/stackrox/actions/blob/c767ee7e36268f87e65f8e212879c9187af2d5db/release/start-secured-cluster/start-secured-cluster.sh#L22

**NOT TESTED YET**