### PR TITLE
ROX-31019: Kube burner should again be able to gather metrics

### DIFF
--- a/release/start-kube-burner/start-kube-burner.sh
+++ b/release/start-kube-burner/start-kube-burner.sh
@@ -35,7 +35,8 @@ kubectl create ns kube-burner
 kubectl create configmap --from-file="$KUBE_BURNER_CONFIG_DIR" kube-burner-config -n kube-burner
 
 temp_metrics_file="${DIR}"/metrics.yml
-cp "${KUBE_BURNER_METRICS_FILE}" "$temp_metrics_file"
+# TODO(ROX-31020): Update kube-burner to a version that can handle captureStart
+sed '/captureStart/d' "${KUBE_BURNER_METRICS_FILE}" > "$temp_metrics_file"
 kubectl create configmap --from-file="$temp_metrics_file" kube-burner-metrics-config -n kube-burner
 
 kubectl create configmap --from-file="$KUBE_BURNER_METRICS_FILE" kube-burner-metrics-config -n kube-burner


### PR DESCRIPTION
Recent changes to the metrics file used by kube-burner in the long running cluster are incompatible with kube-burner in the long running cluster. This aims to fix that problem. The changes that caused the problem are here https://github.com/stackrox/stackrox/pull/16770.

This PR uses sed to remove lines with `captureStart`, which is unknown to the kube-burner version used here. One alternative would be to keep a copy of the metrics file in this repository instead of using the one in stackrox/stackrox. The problem with that is, that it would result in drift between the different versions. This would cause confusion for example if one test used mCPU cores and another used percent CPU usage. Another solution would be to upgrade the kube-burner version used here. The downside is that it might end up requiring other changes. There isn't very much time before the next release, so a simple solution is required. A ticket has been created to update the kube-burner version used for the long running clusters. https://issues.redhat.com/browse/ROX-31020