### PR TITLE
fix: Handle HTTP errors gracefully in wait-for-image action

### DIFF
--- a/release/wait-for-image/wait-for-images.py
+++ b/release/wait-for-image/wait-for-images.py
@@ -94,11 +94,14 @@ def check_image(image, token):
     if token:
         req.add_header('Authorization', f"Bearer {token}")
 
-    with urllib.request.urlopen(req) as resp:
-        body = resp.read().decode('utf-8')
-
-    parsed = json.loads(body)
-    return parsed["tags"] and parsed["tags"][0]["name"] == image.tag
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read().decode('utf-8')
+        parsed = json.loads(body)
+        return parsed["tags"] and parsed["tags"][0]["name"] == image.tag
+    except Exception as e:
+        complain(f"Error checking '{image.name}:{image.tag}': {e}")
+        return False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The action now catches and logs HTTP errors (502, 404, etc.) and network errors instead of crashing, allowing the polling loop to continue until the image appears or timeout is reached.

https://github.com/stackrox/collector/actions/runs/23010218381/job/66818670130?pr=3021

```python
Run "${GITHUB_ACTION_PATH}/wait-for-images.py" \
Will check the following image(s):
rhacs-eng/release-collector:3.24.0-84-ge4063a5f45-fast
Waiting 30 more second(s)...
			⋮
Waiting 30 more second(s)...
Traceback (most recent call last):
  File "/home/runner/work/_actions/stackrox/actions/v1/release/wait-for-image/wait-for-images.py", line 105, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/work/_actions/stackrox/actions/v1/release/wait-for-image/wait-for-images.py", line 14, in main
    res = check_images(args)
          ^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/stackrox/actions/v1/release/wait-for-image/wait-for-images.py", line 70, in check_images
    found[i] = check_image(images[i], args.quay_token)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/stackrox/actions/v1/release/wait-for-image/wait-for-images.py", line 97, in check_image
    with urllib.request.urlopen(req) as resp:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 215, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 521, in open
    response = meth(req, response)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 630, in http_response
    response = self.parent.error(
               ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 559, in error
    return self._call_chain(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 492, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3.12/urllib/request.py", line 639, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 502: Bad Gateway
Error: Process completed with exit code 1.
```