### PR TITLE
ROX-28948: Remove use of cluster density directory from start kube burner

### DIFF
--- a/release/start-kube-burner/start-kube-burner.sh
+++ b/release/start-kube-burner/start-kube-burner.sh
@@ -16,13 +16,6 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 KUBE_BURNER_CONFIG_DIR_BASE="$(dirname "$KUBE_BURNER_CONFIG_DIR")"
 
-# TODO(ROX-28948): When all versions using the cluster-density directory
-# are out of support, remove it from here. The last version to use the
-# cluster-density directory was 4.7.
-if [ ! -d "$KUBE_BURNER_CONFIG_DIR" ]; then
-  KUBE_BURNER_CONFIG_DIR="${KUBE_BURNER_CONFIG_DIR_BASE}/cluster-density"
-fi
-
 dockerconfigjson="$(kubectl -n stackrox get secret stackrox -o yaml | grep dockerconfigjson | head -1 | awk '{print $2}')"
 secret_template="${KUBE_BURNER_CONFIG_DIR_BASE}/secret_template.yml"
 secret_file="${KUBE_BURNER_CONFIG_DIR}/secret.yml"


### PR DESCRIPTION
Prior to 4.8 the directory with the kube-burner configs used for real workload generation was located in the `cluster-density` directory in the stackrox/stackrox repo. That directory was renamed to `berserker-load` for 4.8. Now that 4.7 is no longer supported the logic to switch to using `cluster-density` for older versions can and should be removed.

### Testing

Ran the workflow and checked the clusters.