### PR TITLE
Add reusable action to install roxie CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * [Infra / Install `infractl`](infra/install-infractl/README.md)
 * [Release / Wait for Image](release/wait-for-image/README.md)
 * [Release / Tag](release/tag/README.md)
+* [Roxie / Install CLI](roxie/install-cli/README.md)
 * [Test](test/README.md)
 
 ## Workflows

--- a/roxie/install-cli/README.md
+++ b/roxie/install-cli/README.md
@@ -29,7 +29,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: stackrox/actions/roxie/install-cli@main
+    - uses: stackrox/actions/roxie/install-cli@v1
       with:
         version: v0.4.2
     - run: roxie version

--- a/roxie/install-cli/README.md
+++ b/roxie/install-cli/README.md
@@ -18,7 +18,7 @@ permissions: {}
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
-| `version` | yes | | Release version tag to install (e.g. `v0.4.2`) |
+| `version` | no | latest | Release version tag to install (e.g. `v0.4.2`). Omit to install the latest release. |
 
 ## Usage
 

--- a/roxie/install-cli/README.md
+++ b/roxie/install-cli/README.md
@@ -1,0 +1,36 @@
+# Install roxie CLI
+
+Downloads a [roxie](https://github.com/stackrox/roxie) release binary and
+makes it available in `PATH` for subsequent workflow steps.
+
+The binary is verified against the SHA-256 checksums published with each
+release.
+
+## Recommended permissions
+
+The action doesn't require any specific permission.
+
+```yaml
+permissions: {}
+```
+
+## All options
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `version` | yes | | Release version tag to install (e.g. `v0.4.2`) |
+
+## Usage
+
+```yaml
+name: Deploy ACS
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: stackrox/actions/roxie/install-cli@main
+      with:
+        version: v0.4.2
+    - run: roxie version
+```

--- a/roxie/install-cli/action.yml
+++ b/roxie/install-cli/action.yml
@@ -1,0 +1,16 @@
+name: Install roxie CLI
+description: Download roxie CLI from GitHub releases to ~/.local/bin
+
+inputs:
+  version:
+    description: "Release version tag to install (e.g. v0.4.2)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install roxie
+      shell: bash
+      env:
+        ROXIE_VERSION: ${{ inputs.version }}
+      run: "${GITHUB_ACTION_PATH}/install-roxie.sh"

--- a/roxie/install-cli/action.yml
+++ b/roxie/install-cli/action.yml
@@ -3,8 +3,8 @@ description: Download roxie CLI from GitHub releases to ~/.local/bin
 
 inputs:
   version:
-    description: "Release version tag to install (e.g. v0.4.2)"
-    required: true
+    description: "Release version tag to install (e.g. v0.4.2). Omit to install the latest release."
+    required: false
 
 runs:
   using: composite

--- a/roxie/install-cli/install-roxie.sh
+++ b/roxie/install-cli/install-roxie.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+os=$(uname -s)
+if [[ "$os" != "Linux" ]]; then
+    echo "::error::Unsupported operating system: $os"
+    exit 1
+fi
+
 arch=$(uname -m)
 case "$arch" in
     x86_64)  arch=amd64 ;;
@@ -18,25 +24,30 @@ if [[ -z "${ROXIE_VERSION:-}" ]]; then
     echo "::notice::Resolved latest roxie version: ${ROXIE_VERSION}"
 fi
 
+url="https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/roxie-linux-${arch}"
+echo "::notice::Downloading roxie ${ROXIE_VERSION} (linux/${arch}) from ${url}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/roxie" "$url"
+curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/checksums.txt" \
+    "https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/checksums.txt"
+
+expected=$(grep "roxie-linux-${arch}$" "$tmpdir/checksums.txt" | awk '{print $1}')
+actual=$(sha256sum "$tmpdir/roxie" | awk '{print $1}')
+if [[ "$expected" != "$actual" ]]; then
+    echo "::error::Checksum mismatch: expected ${expected}, got ${actual}"
+    exit 1
+fi
+
 mkdir -p ~/.local/bin
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     PATH="$HOME/.local/bin:$PATH"
     echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 fi
 
-url="https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/roxie-linux-${arch}"
-echo "::notice::Downloading roxie ${ROXIE_VERSION} (linux/${arch}) from ${url}"
-
-curl -fsSL --retry 5 --retry-all-errors -o ~/.local/bin/roxie "$url"
+mv "$tmpdir/roxie" ~/.local/bin/roxie
 chmod +x ~/.local/bin/roxie
-
-curl -fsSL --retry 5 --retry-all-errors -o /tmp/roxie-checksums.txt \
-    "https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/checksums.txt"
-expected=$(grep "roxie-linux-${arch}$" /tmp/roxie-checksums.txt | awk '{print $1}')
-actual=$(sha256sum ~/.local/bin/roxie | awk '{print $1}')
-if [[ "$expected" != "$actual" ]]; then
-    echo "::error::Checksum mismatch: expected ${expected}, got ${actual}"
-    exit 1
-fi
 
 roxie version

--- a/roxie/install-cli/install-roxie.sh
+++ b/roxie/install-cli/install-roxie.sh
@@ -12,6 +12,12 @@ case "$arch" in
         ;;
 esac
 
+if [[ -z "${ROXIE_VERSION:-}" ]]; then
+    ROXIE_VERSION=$(curl -fsSL --retry 5 --retry-all-errors \
+        https://api.github.com/repos/stackrox/roxie/releases/latest | jq -r '.tag_name')
+    echo "::notice::Resolved latest roxie version: ${ROXIE_VERSION}"
+fi
+
 mkdir -p ~/.local/bin
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     PATH="$HOME/.local/bin:$PATH"

--- a/roxie/install-cli/install-roxie.sh
+++ b/roxie/install-cli/install-roxie.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+arch=$(uname -m)
+case "$arch" in
+    x86_64)  arch=amd64 ;;
+    aarch64) arch=arm64 ;;
+    *)
+        echo "::error::Unsupported architecture: $arch"
+        exit 1
+        ;;
+esac
+
+mkdir -p ~/.local/bin
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    PATH="$HOME/.local/bin:$PATH"
+    echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+fi
+
+url="https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/roxie-linux-${arch}"
+echo "::notice::Downloading roxie ${ROXIE_VERSION} (linux/${arch}) from ${url}"
+
+curl -fsSL --retry 5 --retry-all-errors -o ~/.local/bin/roxie "$url"
+chmod +x ~/.local/bin/roxie
+
+curl -fsSL --retry 5 --retry-all-errors -o /tmp/roxie-checksums.txt \
+    "https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/checksums.txt"
+expected=$(grep "roxie-linux-${arch}$" /tmp/roxie-checksums.txt | awk '{print $1}')
+actual=$(sha256sum ~/.local/bin/roxie | awk '{print $1}')
+if [[ "$expected" != "$actual" ]]; then
+    echo "::error::Checksum mismatch: expected ${expected}, got ${actual}"
+    exit 1
+fi
+
+roxie version

--- a/roxie/install-cli/install-roxie.sh
+++ b/roxie/install-cli/install-roxie.sh
@@ -24,17 +24,17 @@ if [[ -z "${ROXIE_VERSION:-}" ]]; then
     echo "::notice::Resolved latest roxie version: ${ROXIE_VERSION}"
 fi
 
-url="https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/roxie-linux-${arch}"
-echo "::notice::Downloading roxie ${ROXIE_VERSION} (linux/${arch}) from ${url}"
+base_url="https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}"
+binary="roxie-linux-${arch}"
+echo "::notice::Downloading roxie ${ROXIE_VERSION} (linux/${arch}) from ${base_url}/${binary}"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/roxie" "$url"
-curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/checksums.txt" \
-    "https://github.com/stackrox/roxie/releases/download/${ROXIE_VERSION}/checksums.txt"
+curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/roxie" "${base_url}/${binary}"
+curl -fsSL --retry 5 --retry-all-errors -o "$tmpdir/checksums.txt" "${base_url}/checksums.txt"
 
-expected=$(grep "roxie-linux-${arch}$" "$tmpdir/checksums.txt" | awk '{print $1}')
+expected=$(awk "/  ${binary}\$/ {print \$1}" "$tmpdir/checksums.txt")
 actual=$(sha256sum "$tmpdir/roxie" | awk '{print $1}')
 if [[ "$expected" != "$actual" ]]; then
     echo "::error::Checksum mismatch: expected ${expected}, got ${actual}"


### PR DESCRIPTION
## Summary
- Adds `roxie/install-cli` composite action that downloads a [roxie](https://github.com/stackrox/roxie) release binary from GitHub releases
- Verifies the downloaded binary against SHA-256 checksums published with each release
- Rejects non-Linux runners early with a clear error
- Detects runner architecture (amd64/arm64) automatically
- Version input is optional — omitting it installs the latest release
- Directory is `roxie/` to allow future additions (e.g. `roxie/deploy`)

## Usage

```yaml
steps:
- uses: stackrox/actions/roxie/install-cli@v1
  with:
    version: v0.4.2
- run: roxie version
```

Or omit `version` to install the latest release:

```yaml
steps:
- uses: stackrox/actions/roxie/install-cli@v1
- run: roxie version
```

## Test plan
- [x] Run action in a workflow with a known roxie version and verify `roxie version` output: in https://github.com/stackrox/stackrox/actions/runs/28446934417/job/84298720305

🤖 Generated with [Claude Code](https://claude.com/claude-code)