### PR TITLE
Install roxie CLI in 'Start ACS' action

### DIFF
--- a/.github/workflows/create-demo-clusters.yml
+++ b/.github/workflows/create-demo-clusters.yml
@@ -345,7 +345,7 @@ jobs:
           infractl artifacts "${NAME//./-}" -d artifacts >> "$GITHUB_STEP_SUMMARY"
       - uses: ./.actions/roxie/install-cli
         with:
-          version: v0.4.3
+          version: v0.4.5
       - name: Launch central
         id: launch-central
         uses: ./.actions/release/start-acs
@@ -446,7 +446,7 @@ jobs:
           password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       - uses: ./.actions/roxie/install-cli
         with:
-          version: v0.4.3
+          version: v0.4.5
       - name: Launch secured cluster
         id: launch-secured-cluster
         uses: ./.actions/release/start-secured-cluster

--- a/release/start-acs/action.yml
+++ b/release/start-acs/action.yml
@@ -40,6 +40,10 @@ runs:
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password }}
 
+    - uses: ./.actions/roxie/install-cli
+      with:
+        version: v0.4.5
+
     - id: launch-central
       env:
         MAIN_IMAGE_TAG: ${{ inputs.main-image-tag }}


### PR DESCRIPTION
Seems it was forgotten in that particular action.

Also: bumped roxie in other actions from 0.4.3 to 0.4.5.
