### PR TITLE
fix(install-relacs): require token and set version to empty

### DIFF
--- a/release/install-relacs/README.md
+++ b/release/install-relacs/README.md
@@ -18,7 +18,8 @@ permissions: {}
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
-| `version` | no | latest | Release version tag to install (e.g. `v0.4.2`). Omit to install the latest release. |
+| `token` | yes |  | GH token to use for authentication for the `relacs` repository. |
+| `version` | no | "" | Release version tag to install (e.g. `v0.4.2`). Omit to install the latest release. |
 
 ## Usage
 
@@ -31,6 +32,7 @@ jobs:
     steps:
     - uses: stackrox/actions/release/install-relacs@v1
       with:
+        token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
         version: v0.4.2
 
     - run: relacs version

--- a/release/install-relacs/action.yml
+++ b/release/install-relacs/action.yml
@@ -2,10 +2,13 @@ name: Install relacs CLI
 description: Download relacs CLI from GitHub releases to ~/.local/bin
 
 inputs:
+  token:
+    description: "GitHub token to use for authentication"
+    required: true
   version:
     description: "Release version tag to install (e.g. v0.4.2). Omit to install the latest release."
     required: false
-    default: 'latest'
+    default: ""
 
 runs:
   using: composite
@@ -13,7 +16,7 @@ runs:
     - name: Download and install relacs
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.token }}
         VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail


### PR DESCRIPTION
* Require token to authenticate the GH API calls, proof: https://github.com/tommartensen/test-gh-actions/actions/runs/30909057517/job/91990962650#step:2:1
  * if token is missing, it fails like: https://github.com/tommartensen/test-gh-actions/actions/runs/30905483573/job/91979454939
* The default value for `version` should be empty (defaulting to install latest version). A literal "latest" version would fail with "release not found". 