### PR TITLE
ROX-36256: File activity policies for long running clusters

### DIFF
--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -68,6 +68,20 @@ kubectl -n stackrox create secret generic access-rhacs \
     --from-literal="password=${ROX_ADMIN_PASSWORD}" \
     --from-literal="central_url=https://${CENTRAL_IP}"
 
+POLICIES_DIR="${STACKROX_DIR}/scripts/release-tools/long-running-cluster/policies"
+if [[ -d "$POLICIES_DIR" ]]; then
+    gh_log notice "Applying security policies from ${POLICIES_DIR}..."
+    for policy_file in "$POLICIES_DIR"/*.yaml; do
+        if kubectl apply -f "$policy_file"; then
+            gh_log notice "Applied security policy: $(basename "$policy_file")"
+        else
+            gh_log warning "Failed to apply security policy: $(basename "$policy_file")"
+        fi
+    done
+else
+    gh_log notice "No security policies directory found at ${POLICIES_DIR}, skipping."
+fi
+
 gh_summary <<EOSUMMARY
 Long-running GKE cluster ${NAME//./-} has been patched.
 Access it by running:

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -70,14 +70,21 @@ kubectl -n stackrox create secret generic access-rhacs \
 
 POLICIES_DIR="${STACKROX_DIR}/scripts/release-tools/long-running-cluster/policies"
 if [[ -d "$POLICIES_DIR" ]]; then
-    gh_log notice "Applying security policies from ${POLICIES_DIR}..."
-    for policy_file in "$POLICIES_DIR"/*.yaml; do
-        if kubectl apply -f "$policy_file"; then
-            gh_log notice "Applied security policy: $(basename "$policy_file")"
-        else
-            gh_log warning "Failed to apply security policy: $(basename "$policy_file")"
-        fi
-    done
+    shopt -s nullglob
+    policy_files=("$POLICIES_DIR"/*.yaml)
+    shopt -u nullglob
+    if [[ ${#policy_files[@]} -eq 0 ]]; then
+        gh_log notice "No YAML policy files found in ${POLICIES_DIR}, skipping."
+    else
+        gh_log notice "Applying security policies from ${POLICIES_DIR}..."
+        for policy_file in "${policy_files[@]}"; do
+            if kubectl apply -f "$policy_file"; then
+                gh_log notice "Applied security policy: $(basename "$policy_file")"
+            else
+                gh_log warning "Failed to apply security policy: $(basename "$policy_file")"
+            fi
+        done
+    fi
 else
     gh_log notice "No security policies directory found at ${POLICIES_DIR}, skipping."
 fi

--- a/release/start-acs/start-acs.sh
+++ b/release/start-acs/start-acs.sh
@@ -69,6 +69,7 @@ kubectl -n stackrox create secret generic access-rhacs \
     --from-literal="central_url=https://${CENTRAL_IP}"
 
 POLICIES_DIR="${STACKROX_DIR}/scripts/release-tools/long-running-cluster/policies"
+policy_failure=false
 if [[ -d "$POLICIES_DIR" ]]; then
     shopt -s nullglob
     policy_files=("$POLICIES_DIR"/*.yaml)
@@ -81,12 +82,18 @@ if [[ -d "$POLICIES_DIR" ]]; then
             if kubectl apply -f "$policy_file"; then
                 gh_log notice "Applied security policy: $(basename "$policy_file")"
             else
-                gh_log warning "Failed to apply security policy: $(basename "$policy_file")"
+                gh_log error "Failed to apply security policy: $(basename "$policy_file")"
+                policy_failure=true
             fi
         done
     fi
 else
     gh_log notice "No security policies directory found at ${POLICIES_DIR}, skipping."
+fi
+
+if [[ "$policy_failure" == "true" ]]; then
+    gh_log error "One or more security policies failed to apply. Exiting."
+    exit 1
 fi
 
 gh_summary <<EOSUMMARY


### PR DESCRIPTION
The long running cluster has real file activity workload. However, it does not have any file activity policies that are triggered by that workload. That means there is no stress resulting from file activity policy violations. This PR changes that.

This PR applies a SecurityPolicy CR found in the stackrox/stackrox, with a file activity policy.

The actual SecurityPolicy CR can be found at https://github.com/stackrox/stackrox/pull/22236

Testing for this PR can be found there.